### PR TITLE
Add the Haystack cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ Notebook |Category| Description
 [basic_RAG.ipynb](https://github.com/mistralai/cookbook/blob/main/basic_RAG.ipynb) | RAG| RAG from scratch with Mistral AI API
 [embeddings.ipynb](https://github.com/mistralai/cookbook/blob/main/embeddings.ipynb) | embeddings| Use Mistral embeddings API for classification and clustering
 [llamaindex_agentic_rag.ipynb](https://github.com/mistralai/cookbook/blob/main/llamaindex_agentic_rag.ipynb) | RAG, agent| Use Mistral AI with LlamaIndex and ReAct agent
+[haystack_chat_with_docs.ipynb](https://github.com/mistralai/cookbook/blob/main/haystack_chat_with_docs.ipynb) | RAG, embeddings | Use Mistral AI with Haystack indexing and RAG pipelines

--- a/haystack_chat_with_docs.ipynb
+++ b/haystack_chat_with_docs.ipynb
@@ -1,0 +1,191 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using Mistral AI with Haystack\n",
+    "\n",
+    "In this cookbook, we will use Mistral embeddings and generative models in 2 [Haystack](https://github.com/deepset-ai/haystack) pipelines:\n",
+    "\n",
+    "1) We will build an indexing pipeline that can create embeddings for the contents of URLs and indexes them into a vector database\n",
+    "2) We will build a retrieval-augmented chat pipeline to chat with the contents of the URLs\n",
+    "\n",
+    "First, we install our dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install mistral-haystack"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we need to set the `MISTRAL_API_KEY` environment variable 👇"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "\n",
+    "os.environ[\"MISTRAL_API_KEY\"] = getpass(\"Mistral API Key:\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Index URLs with Mistral Embeddings\n",
+    "\n",
+    "Below, we are using `mistral-embed` in a full Haysack indexing pipeline. We create embeddings for the contents of the chosen URLs with `mistral-embed` and write them to an [`InMemoryDocumentStore`](https://docs.haystack.deepset.ai/v2.0/docs/inmemorydocumentstore) using the [`MistralDocumentEmbedder`](https://docs.haystack.deepset.ai/v2.0/docs/mistraldocumentembedder). \n",
+    "\n",
+    "> 💡This document store is the simplest to get started with as it has no requirements to setup. Feel free to change this document store to any of the [vector databases available for Haystack 2.0](https://haystack.deepset.ai/integrations?type=Document+Store) such as **Weaviate**, **Chroma**, **AstraDB** etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from haystack import Pipeline\n",
+    "from haystack.components.converters import HTMLToDocument\n",
+    "from haystack.components.fetchers import LinkContentFetcher\n",
+    "from haystack.components.preprocessors import DocumentSplitter\n",
+    "from haystack.components.writers import DocumentWriter\n",
+    "from haystack.document_stores.in_memory import InMemoryDocumentStore\n",
+    "from haystack_integrations.components.embedders.mistral.document_embedder import MistralDocumentEmbedder\n",
+    "\n",
+    "\n",
+    "document_store = InMemoryDocumentStore()\n",
+    "fetcher = LinkContentFetcher()\n",
+    "converter = HTMLToDocument()\n",
+    "embedder = MistralDocumentEmbedder()\n",
+    "writer = DocumentWriter(document_store=document_store)\n",
+    "\n",
+    "indexing = Pipeline()\n",
+    "\n",
+    "indexing.add_component(name=\"fetcher\", instance=fetcher)\n",
+    "indexing.add_component(name=\"converter\", instance=converter)\n",
+    "indexing.add_component(name=\"embedder\", instance=embedder)\n",
+    "indexing.add_component(name=\"writer\", instance=writer)\n",
+    "\n",
+    "indexing.connect(\"fetcher\", \"converter\")\n",
+    "indexing.connect(\"converter\", \"embedder\")\n",
+    "indexing.connect(\"embedder\", \"writer\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\"https://mistral.ai/news/la-plateforme/\", \"https://mistral.ai/news/mixtral-of-experts\"]\n",
+    "\n",
+    "indexing.run({\"fetcher\": {\"urls\": urls}})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chat With the URLs with Mistral Generative Models\n",
+    "\n",
+    "Now that we have indexed the contents and embeddings of various URLs, we can create a RAG pipeline that uses the [`MistralChatGenerator`](https://docs.haystack.deepset.ai/v2.0/docs/mistralchatgenerator) component with `mistral-small`.\n",
+    "A few more things to know about this pipeline:\n",
+    "\n",
+    "- We are using the [`MistralTextEmbdder`](https://docs.haystack.deepset.ai/v2.0/docs/mistraltextembedder) to embed our question and retrieve the most relevant 1 document\n",
+    "- We are enabling streming responses by providing a `streaming_callback`\n",
+    "- `documents` is being provided to the chat template by the retriever, while we provide `query` to the pipeline when we run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from haystack import Pipeline\n",
+    "from haystack.components.builders import DynamicChatPromptBuilder\n",
+    "from haystack.components.generators.utils import print_streaming_chunk\n",
+    "from haystack.components.retrievers.in_memory import InMemoryEmbeddingRetriever\n",
+    "from haystack.dataclasses import ChatMessage\n",
+    "from haystack_integrations.components.embedders.mistral.text_embedder import MistralTextEmbedder\n",
+    "from haystack_integrations.components.generators.mistral import MistralChatGenerator\n",
+    "\n",
+    "text_embedder = MistralTextEmbedder()\n",
+    "retriever = InMemoryEmbeddingRetriever(document_store=document_store, top_k=1)\n",
+    "prompt_builder = DynamicChatPromptBuilder(runtime_variables=[\"documents\"])\n",
+    "llm = MistralChatGenerator(model='mistral-small', streaming_callback=print_streaming_chunk)\n",
+    "\n",
+    "rag_pipeline = Pipeline()\n",
+    "rag_pipeline.add_component(\"text_embedder\", text_embedder)\n",
+    "rag_pipeline.add_component(\"retriever\", retriever)\n",
+    "rag_pipeline.add_component(\"prompt_builder\", prompt_builder)\n",
+    "rag_pipeline.add_component(\"llm\", llm)\n",
+    "\n",
+    "\n",
+    "rag_pipeline.connect(\"text_embedder.embedding\", \"retriever.query_embedding\")\n",
+    "rag_pipeline.connect(\"retriever.documents\", \"prompt_builder.documents\")\n",
+    "rag_pipeline.connect(\"prompt_builder.prompt\", \"llm.messages\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "question = \"What generative endpoints does the Mistral platform have?\"\n",
+    "\n",
+    "chat_template = \"\"\"Answer the following question based on the contents of the documents.\\n\n",
+    "                Question: {{query}}\\n\n",
+    "                Documents: {{documents[0].content}}\n",
+    "                \"\"\"\n",
+    "messages = [ChatMessage.from_user(chat_template)]\n",
+    "\n",
+    "result = rag_pipeline.run(\n",
+    "    {\n",
+    "        \"text_embedder\": {\"text\": question},\n",
+    "        \"prompt_builder\": {\"template_variables\": {\"query\": question}, \"prompt_source\": messages},\n",
+    "        \"llm\": {\"generation_kwargs\": {\"max_tokens\": 165}},\n",
+    "    },\n",
+    "    debug=True\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mistral",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/haystack_chat_with_docs.ipynb
+++ b/haystack_chat_with_docs.ipynb
@@ -62,7 +62,6 @@
     "from haystack import Pipeline\n",
     "from haystack.components.converters import HTMLToDocument\n",
     "from haystack.components.fetchers import LinkContentFetcher\n",
-    "from haystack.components.preprocessors import DocumentSplitter\n",
     "from haystack.components.writers import DocumentWriter\n",
     "from haystack.document_stores.in_memory import InMemoryDocumentStore\n",
     "from haystack_integrations.components.embedders.mistral.document_embedder import MistralDocumentEmbedder\n",


### PR DESCRIPTION
This PR adds a cookbook that does 2 things:
1) Creates embeddings for the contents of given URLs using Mistral embeddings
2) Does RAG (technically retrieval augmented chat) using `mistral-small` on the contents of the indexed documents. 

The example indexes 2 of mistrals own webpages and streams the response.