### PR TITLE
fix: Remove duplicate 'the' in SQL dialect description

### DIFF
--- a/neon_text_to_sql.ipynb
+++ b/neon_text_to_sql.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Translating natural language queries into SQL statements is a powerful application of large language models (LLMs). While it's possible to ask an LLM directly to generate SQL based on a natural language prompt, it comes with limitations.\n",
     "\n",
-    "1. The LLM may generate SQL that is syntactically incorrect since the the SQL dialect varies across relational databases.\n",
+    "1. The LLM may generate SQL that is syntactically incorrect since the SQL dialect varies across relational databases.\n",
     "2. The LLM doesn't have access to the full database schema, table and column names or indexes, which limits its ability to generate accurate/efficient queries. Passing in the full schema as input to the LLM everytime can get expensive.\n",
     "3. Pretrained LLMs can't adapt to user feedback and evolving text queries.\n",
     "\n",


### PR DESCRIPTION
- Corrected a "the" duplication error in the sentence explaining SQL dialect variations.