### PR TITLE
fix: Correct typo and add missing comma

### DIFF
--- a/neon_text_to_sql.ipynb
+++ b/neon_text_to_sql.ipynb
@@ -370,7 +370,7 @@
     "1. Your task is to generate an SQL query that will retrieve the data needed to answer the question, based on the database schema. \n",
     "2. First, carefully study the provided schema and examples to understand the structure of the database and how the examples map natural language to SQL for this schema.\n",
     "3. Your answer should have two parts: \n",
-    "- Inside <scratchpad> XML tag, write out step-by-step reasoning to explain how you are generating the query based on the schema, exampled and question. \n",
+    "- Inside <scratchpad> XML tag, write out step-by-step reasoning to explain how you are generating the query based on the schema, example, and question. \n",
     "- Then, inside <sql> XML tag, output your generated SQL. \n",
     "\"\"\"\n",
     "\n",


### PR DESCRIPTION
- Fixed the typo by changing "exampled" to "example" for consistency with singular terms and added the missing comma in the instructions for generating the query based on the schema, example, and question.