### PR TITLE
fix: Corrected spelling of "streming"

### DIFF
--- a/haystack_chat_with_docs.ipynb
+++ b/haystack_chat_with_docs.ipynb
@@ -106,7 +106,7 @@
     "A few more things to know about this pipeline:\n",
     "\n",
     "- We are using the [`MistralTextEmbdder`](https://docs.haystack.deepset.ai/v2.0/docs/mistraltextembedder) to embed our question and retrieve the most relevant 1 document\n",
-    "- We are enabling streming responses by providing a `streaming_callback`\n",
+    "- We are enabling streaming responses by providing a `streaming_callback`\n",
     "- `documents` is being provided to the chat template by the retriever, while we provide `query` to the pipeline when we run it."
    ]
   },


### PR DESCRIPTION
fix: Corrected spelling of "streming" to "streaming" in markdown content