### PR TITLE
fix: Corrected spelling of "Haysack"

### DIFF
--- a/haystack_chat_with_docs.ipynb
+++ b/haystack_chat_with_docs.ipynb
@@ -48,7 +48,7 @@
    "source": [
     "## Index URLs with Mistral Embeddings\n",
     "\n",
-    "Below, we are using `mistral-embed` in a full Haysack indexing pipeline. We create embeddings for the contents of the chosen URLs with `mistral-embed` and write them to an [`InMemoryDocumentStore`](https://docs.haystack.deepset.ai/v2.0/docs/inmemorydocumentstore) using the [`MistralDocumentEmbedder`](https://docs.haystack.deepset.ai/v2.0/docs/mistraldocumentembedder). \n",
+    "Below, we are using `mistral-embed` in a full Haystack indexing pipeline. We create embeddings for the contents of the chosen URLs with `mistral-embed` and write them to an [`InMemoryDocumentStore`](https://docs.haystack.deepset.ai/v2.0/docs/inmemorydocumentstore) using the [`MistralDocumentEmbedder`](https://docs.haystack.deepset.ai/v2.0/docs/mistraldocumentembedder). \n",
     "\n",
     "> 💡This document store is the simplest to get started with as it has no requirements to setup. Feel free to change this document store to any of the [vector databases available for Haystack 2.0](https://haystack.deepset.ai/integrations?type=Document+Store) such as **Weaviate**, **Chroma**, **AstraDB** etc."
    ]


### PR DESCRIPTION
fix: Corrected spelling of "Haysack" to "Haystack" in markdown content