### PR TITLE
fix: Corrected spelling error "vectore"

### DIFF
--- a/basic_RAG.ipynb
+++ b/basic_RAG.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Basic RAG\n",
-    "Retrieval-augmented generation (RAG) is an AI framework that synergizes the capabilities of LLMs and information retrieval systems. It’s useful to answer questions or generate content leveraging external knowledge. There are two main steps in RAG: 1) retrieval: retrieve relevant information from a knowledge base with text embeddings stored in a vectore store; 2) generation: insert the relevant information to the prompt for the LLM to generate information. In this guide, we will walk through a very basic example of RAG with four implementations:\n",
+    "Retrieval-augmented generation (RAG) is an AI framework that synergizes the capabilities of LLMs and information retrieval systems. It’s useful to answer questions or generate content leveraging external knowledge. There are two main steps in RAG: 1) retrieval: retrieve relevant information from a knowledge base with text embeddings stored in a vector store; 2) generation: insert the relevant information to the prompt for the LLM to generate information. In this guide, we will walk through a very basic example of RAG with four implementations:\n",
     "\n",
     "- RAG from scratch with Mistral\n",
     "- RAG with Mistral and LangChain\n",


### PR DESCRIPTION
- Corrected the spelling of "vectore" to "vector" in the markdown content.