### PR TITLE
fix: broken links after folder rename in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [prefix_use_cases.ipynb](mistral/prompting/prefix_use_cases.ipynb)             | prefix, prompting            | Cool examples with Mistral's prefix feature                                      |
 | [synthetic_data_gen_and_finetune.ipynb](mistral/data_generation/synthetic_data_gen_and_finetune.ipynb) | data generation, fine-tuning | Simple data generation and fine-tuning guide        |
 | [data_generation_refining_news.ipynb](mistral/data_generation/data_generation_refining_news.ipynb) | data generation | Simple data generation to refine news articles                                |
-| [image_description_extraction_pixtral.ipynb](mistral/image_processing/image_description_extraction_pixtral.ipynb) | image processing, prompting  | Extract structured image descriptions using Mistral's Pixtral model and JSON response formatting |
-| [multimodality meets function calling.ipynb](mistral/image_processing/multimodality_meets_function_calling.ipynb.ipynb) | image processing, function calling  | Extract table from image using Mistral's Pixtral model and use for function calling |
+| [image_description_extraction_pixtral.ipynb](mistral/image_understanding/image_description_extraction_pixtral.ipynb) | image processing, prompting  | Extract structured image descriptions using Mistral's Pixtral model and JSON response formatting |
+| [multimodality meets function calling.ipynb](mistral/image_understanding/multimodality_meets_function_calling.ipynb) | image processing, function calling  | Extract table from image using Mistral's Pixtral model and use for function calling |
 | [mistral-reference-rag.ipynb](mistral/rag/mistral-reference-rag.ipynb) | RAG, function calling, references | Reference RAG with Mistral API |
 | [moderation-explored.ipynb](mistral/moderation/moderation-explored.ipynb) | moderation | Quick exploration on safeguarding and Mistral's moderation API |
 | [system-level-guardrails.ipynb](mistral/moderation/system-level-guardrails.ipynb) | moderation | How to implement System Level Guardrails with Mistral API |


### PR DESCRIPTION
# Cookbook Pull Request

## Description

Fixed the links to the notebooks in `image_understanding`

## Type of Change

What type of PR is it?
- README.md Update

## Cookbook Checklist:

- [x] My changes do not concern the cookbooks.