### PR TITLE
fix(readme): correct SubQuestionQueryEngine link and fix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [Solara Integration - Chat with PDFs](third_party/solara/README.md)                                                   | UI chat, demo, RAG              | Solara     |
 | [Streamlit Integration - Chat with PDF](third_party/streamlit/README.md)                                              | UI chat, demo, RAG              | Streamlit  |
 | [Neo4j rag](third_party/Neo4j/neo4j_rag.ipynb)                                                                        | RAG                             | Neo4j      |
-| [SubQuestionQueryEngine.ipynb](third_party/LlamaIndex/RouterQueryEngine.ipynb)                                        | agent                           | LLamaIndex |
+| [SubQuestionQueryEngine.ipynb](third_party/LlamaIndex/SubQuestionQueryEngine.ipynb)                                   | agent                           | LLamaIndex |
 | [LLM Judge: Detecting hallucinations in language models](third_party/wandb/README.md)                                 | fine-tuning, evaluation         | Weights & Biases |
 | [`x mistral`: CLI & TUI APP Module in X-CMD](third_party/x-cmd/README.md)                                             | CLI, TUI APP, Chat              | x-cmd      |
 | [Incremental Prompt Engineering and Model Comparison](third_party/Pixeltable/README.md)                               | Prompt Engineering, Evaluation  | Pixeltable |
 | [Build a bank support agent with Pydantic AI and Mistral AI](third_party/PydanticAI/pydantic_bank_support_agent.ipynb)| Agent                           | Pydantic   |
 | [Mistral and MLflow Tracing](third_party/MLflow/mistral-mlflow-tracing.ipynb)                                         | Tracing, Observability          | MLflow     |
 | [Mistral OCR with Gradio](third_party/gradio/MistralOCR.md)                                                           | OCR                             | Gradio     |
-| [prompt_optimization.ipynb](third_party/metagpt/prompt_optimization.ipynb)) |Prompting | Optimizing prompts without any supervision
+| [prompt_optimization.ipynb](third_party/metagpt/prompt_optimization.ipynb) | Prompting | Optimizing prompts without any supervision |


### PR DESCRIPTION
## Cookbook Pull Request

## Description

Fixes two additional README issues related to #244 (complementary to #245):

1. **`SubQuestionQueryEngine.ipynb` wrong link target**: The link text says `SubQuestionQueryEngine.ipynb` but pointed to `third_party/LlamaIndex/RouterQueryEngine.ipynb`. Fixed to point to the correct file `third_party/LlamaIndex/SubQuestionQueryEngine.ipynb` (which exists).

2. **`prompt_optimization.ipynb` formatting**: Double closing parenthesis `))` broke the markdown link syntax. Also added missing trailing pipe `|` to complete the table row.

## Type of Change

- [ ] New Cookbook
- [ ] Cookbook Update
- [X] README.md Update
___
- [ ] Other

## Cookbook Checklist:

- [X] My code is easy to read and well structured.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings or errors.
___
- [X] My changes do not concern the cookbooks.

## README.md Checklist

- [ ] I've added my cookbook to the table.
___
- [X] My changes do not concern the README file.

## Additional Context

These fixes complement PR #245 which addresses the four dead links (404) reported in issue #244. The two issues fixed here were not covered by that PR.