### PR TITLE
feat(notebook): add reasoning capabilities cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [intent_classification.ipynb](mistral/classifier_factory/intent_classification.ipynb) | fine-tuning, classifier | Fine-tuning a classifier for intent classification. |
 | [moderation_classifier.ipynb](mistral/classifier_factory/moderation_classifier.ipynb) | fine-tuning, classifier | Fine-tuning a classifier for moderation. |
 | [pixtral_finetune_on_satellite_data.ipynb](mistral/fine_tune/pixtral_finetune_on_satellite_data.ipynb) | fine-tuning, image processing, batch | Fine-tuning a Pixtral-12B for satellite images classification. |
+| [reasoning_capabilities.ipynb](mistral/reasoning/reasoning_capabilities.ipynb) | reasoning, chain-of-thought | Explore reasoning capabilities with Magistral models: CoT, math, logic, and code analysis |
 
 
 

--- a/mistral/reasoning/reasoning_capabilities.ipynb
+++ b/mistral/reasoning/reasoning_capabilities.ipynb
@@ -1,0 +1,465 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-title",
+   "metadata": {},
+   "source": [
+    "# Reasoning Capabilities with Mistral AI\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mistralai/cookbook/blob/main/mistral/reasoning/reasoning_capabilities.ipynb)\n",
+    "\n",
+    "This notebook explores the reasoning capabilities of Mistral's **Magistral** models, demonstrating chain-of-thought prompting, mathematical reasoning, logical deduction, and code analysis.\n",
+    "\n",
+    "Mistral's reasoning models (`magistral-small-latest`, `magistral-medium-latest`) use **Test Time Computation** to explore problems more deeply by generating additional tokens during inference, producing structured thinking traces alongside final answers.\n",
+    "\n",
+    "**What you'll learn:**\n",
+    "- How to use Mistral's Magistral reasoning models\n",
+    "- How to parse thinking traces vs. final answers\n",
+    "- Chain-of-thought prompting for complex problems\n",
+    "- Mathematical reasoning, logical deduction, and code analysis\n",
+    "- Comparing results with and without reasoning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install mistralai==1.12.4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from mistralai import Mistral\n",
+    "\n",
+    "api_key = os.environ.get(\"MISTRAL_API_KEY\")\n",
+    "client = Mistral(api_key=api_key)\n",
+    "\n",
+    "REASONING_MODEL = \"magistral-medium-latest\"\n",
+    "STANDARD_MODEL = \"mistral-large-latest\"\n",
+    "\n",
+    "\n",
+    "def chat(prompt, model=REASONING_MODEL, system=None):\n",
+    "    \"\"\"Send a prompt and return the full response content.\"\"\"\n",
+    "    messages = []\n",
+    "    if system:\n",
+    "        messages.append({\"role\": \"system\", \"content\": system})\n",
+    "    messages.append({\"role\": \"user\", \"content\": prompt})\n",
+    "    response = client.chat.complete(model=model, messages=messages)\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "\n",
+    "def chat_with_traces(prompt, model=REASONING_MODEL, system=None):\n",
+    "    \"\"\"Send a prompt and return thinking traces and final answer separately.\"\"\"\n",
+    "    messages = []\n",
+    "    if system:\n",
+    "        messages.append({\"role\": \"system\", \"content\": system})\n",
+    "    messages.append({\"role\": \"user\", \"content\": prompt})\n",
+    "    response = client.chat.complete(model=model, messages=messages)\n",
+    "    content = response.choices[0].message.content\n",
+    "\n",
+    "    thinking = []\n",
+    "    answer = []\n",
+    "    if isinstance(content, list):\n",
+    "        for block in content:\n",
+    "            if hasattr(block, \"type\"):\n",
+    "                if block.type == \"thinking\":\n",
+    "                    thinking.append(block.text)\n",
+    "                elif block.type == \"text\":\n",
+    "                    answer.append(block.text)\n",
+    "    else:\n",
+    "        answer.append(str(content))\n",
+    "\n",
+    "    return {\n",
+    "        \"thinking\": \"\\n\".join(thinking),\n",
+    "        \"answer\": \"\\n\".join(answer),\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-section1",
+   "metadata": {},
+   "source": [
+    "## 1. Understanding Reasoning Model Output\n",
+    "\n",
+    "Magistral models split their output into two parts:\n",
+    "- **Thinking blocks** (`type: \"thinking\"`): The model's internal reasoning traces\n",
+    "- **Text blocks** (`type: \"text\"`): The final answer\n",
+    "\n",
+    "Let's start with a simple example to see how thinking traces work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-traces-demo",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = chat_with_traces(\n",
+    "    \"If a shirt costs $25 after a 20% discount, what was the original price?\"\n",
+    ")\n",
+    "\n",
+    "print(\"=== Thinking Traces ===\")\n",
+    "print(result[\"thinking\"])\n",
+    "print(\"\\n=== Final Answer ===\")\n",
+    "print(result[\"answer\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-section2",
+   "metadata": {},
+   "source": [
+    "## 2. Chain-of-Thought Prompting\n",
+    "\n",
+    "Chain-of-thought (CoT) prompting encourages the model to break down a problem into intermediate steps. While Magistral models naturally produce reasoning traces, explicit CoT instructions can further improve results on complex problems."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-cot-basic",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cot_prompt = \"\"\"A farmer has 3 fields. The first field produces 240 kg of wheat per hectare.\n",
+    "The second field produces 15% more than the first. The third field produces 10% less\n",
+    "than the second. If each field is 5 hectares, what is the total wheat production?\n",
+    "\n",
+    "Think step by step.\"\"\"\n",
+    "\n",
+    "result = chat_with_traces(cot_prompt)\n",
+    "\n",
+    "print(\"=== Thinking Traces ===\")\n",
+    "print(result[\"thinking\"])\n",
+    "print(\"\\n=== Final Answer ===\")\n",
+    "print(result[\"answer\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-section3",
+   "metadata": {},
+   "source": [
+    "## 3. Mathematical Reasoning\n",
+    "\n",
+    "Magistral models excel at multi-step mathematical problems. Let's test with a problem that requires careful algebraic reasoning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-math",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "math_prompt = \"\"\"A train leaves City A at 9:00 AM traveling at 80 km/h toward City B.\n",
+    "Another train leaves City B at 10:00 AM traveling at 100 km/h toward City A.\n",
+    "The cities are 500 km apart.\n",
+    "\n",
+    "1. At what time do the trains meet?\n",
+    "2. How far from City A is the meeting point?\n",
+    "3. If a bird starts flying at 120 km/h from City A at 9:00 AM, bouncing back\n",
+    "   and forth between the two trains until they meet, what total distance does\n",
+    "   the bird fly?\n",
+    "\n",
+    "Show your work for each question.\"\"\"\n",
+    "\n",
+    "result = chat_with_traces(math_prompt)\n",
+    "\n",
+    "print(\"=== Thinking Traces ===\")\n",
+    "print(result[\"thinking\"][:2000])  # Truncated for readability\n",
+    "print(\"\\n=== Final Answer ===\")\n",
+    "print(result[\"answer\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-section4",
+   "metadata": {},
+   "source": [
+    "## 4. Logical Deduction\n",
+    "\n",
+    "Let's test the model's ability to solve a classic logic puzzle that requires careful deductive reasoning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-logic",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logic_prompt = \"\"\"There are 4 people: Alice, Bob, Carol, and Dave.\n",
+    "\n",
+    "Facts:\n",
+    "- One of them always tells the truth, one always lies, and the other two\n",
+    "  sometimes lie and sometimes tell the truth.\n",
+    "- Alice says: \"Bob is the liar.\"\n",
+    "- Bob says: \"Carol always tells the truth.\"\n",
+    "- Carol says: \"Dave is not the truth-teller.\"\n",
+    "- Dave says: \"Alice is not the liar.\"\n",
+    "\n",
+    "We also know:\n",
+    "- The liar's statement is always false.\n",
+    "- The truth-teller's statement is always true.\n",
+    "\n",
+    "Who is the truth-teller and who is the liar? Explain your reasoning step by step.\"\"\"\n",
+    "\n",
+    "result = chat_with_traces(logic_prompt)\n",
+    "\n",
+    "print(\"=== Thinking Traces ===\")\n",
+    "print(result[\"thinking\"][:2000])\n",
+    "print(\"\\n=== Final Answer ===\")\n",
+    "print(result[\"answer\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-section5",
+   "metadata": {},
+   "source": [
+    "## 5. Code Analysis and Bug Detection\n",
+    "\n",
+    "Reasoning models are particularly good at analyzing code, tracing execution paths, and identifying bugs. Let's give the model a piece of buggy code and ask it to find the issues."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-code-analysis",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "code_prompt = \"\"\"Analyze the following Python function. It's supposed to find the\n",
+    "longest substring without repeating characters, but it has bugs. Identify all\n",
+    "bugs and provide the corrected version.\n",
+    "\n",
+    "```python\n",
+    "def longest_unique_substring(s):\n",
+    "    max_len = 0\n",
+    "    start = 0\n",
+    "    seen = {}\n",
+    "    result = \"\"\n",
+    "\n",
+    "    for end in range(len(s)):\n",
+    "        if s[end] in seen:\n",
+    "            start = seen[s[end]] + 1  # Bug: doesn't handle case where seen[s[end]] < start\n",
+    "        seen[s[end]] = end\n",
+    "        if end - start > max_len:  # Bug: should be >= for correct length calculation\n",
+    "            max_len = end - start\n",
+    "            result = s[start:end]  # Bug: should be s[start:end+1]\n",
+    "\n",
+    "    return result\n",
+    "\n",
+    "# Test cases:\n",
+    "# longest_unique_substring(\"abcabcbb\") should return \"abc\"\n",
+    "# longest_unique_substring(\"bbbbb\") should return \"b\"\n",
+    "# longest_unique_substring(\"pwwkew\") should return \"wke\"\n",
+    "```\n",
+    "\n",
+    "For each bug:\n",
+    "1. Explain what goes wrong\n",
+    "2. Provide a test case that triggers the bug\n",
+    "3. Show the fix\"\"\"\n",
+    "\n",
+    "result = chat_with_traces(code_prompt)\n",
+    "\n",
+    "print(\"=== Thinking Traces ===\")\n",
+    "print(result[\"thinking\"][:2000])\n",
+    "print(\"\\n=== Final Answer ===\")\n",
+    "print(result[\"answer\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-section6",
+   "metadata": {},
+   "source": [
+    "## 6. Comparison: Reasoning Model vs. Standard Model\n",
+    "\n",
+    "Let's compare how a reasoning model (`magistral-medium-latest`) and a standard model (`mistral-large-latest`) handle the same complex problem. This highlights the value of extended reasoning for difficult tasks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-comparison",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "comparison_prompt = \"\"\"A snail is at the bottom of a 30-meter well. Each day, it climbs\n",
+    "up 3 meters, but each night, it slips back 2 meters. On what day does the snail\n",
+    "reach the top of the well?\n",
+    "\n",
+    "Be careful — this is a classic trick question. Think through it carefully.\"\"\"\n",
+    "\n",
+    "# Reasoning model (Magistral)\n",
+    "print(\"=== Magistral (Reasoning Model) ===\")\n",
+    "reasoning_result = chat_with_traces(comparison_prompt, model=REASONING_MODEL)\n",
+    "print(\"Thinking:\")\n",
+    "print(reasoning_result[\"thinking\"][:1500])\n",
+    "print(\"\\nAnswer:\")\n",
+    "print(reasoning_result[\"answer\"])\n",
+    "\n",
+    "print(\"\\n\" + \"=\" * 60 + \"\\n\")\n",
+    "\n",
+    "# Standard model\n",
+    "print(\"=== Mistral Large (Standard Model) ===\")\n",
+    "standard_result = chat(comparison_prompt, model=STANDARD_MODEL)\n",
+    "print(standard_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-section7",
+   "metadata": {},
+   "source": [
+    "## 7. Advanced: Controlling Reasoning with `prompt_mode`\n",
+    "\n",
+    "Magistral models support a `prompt_mode` parameter to control their behavior:\n",
+    "- `\"reasoning\"` (default): Uses the built-in reasoning system prompt\n",
+    "- `None`: No system prompt — useful when providing your own instructions\n",
+    "\n",
+    "You can also override the default system prompt by providing your own."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-prompt-mode",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_system = \"\"\"You are a mathematics tutor. When solving problems:\n",
+    "1. State the given information\n",
+    "2. Identify what is being asked\n",
+    "3. Choose the appropriate method\n",
+    "4. Solve step by step\n",
+    "5. Verify your answer\"\"\"\n",
+    "\n",
+    "problem = \"\"\"Find all real solutions to the equation:\n",
+    "x^4 - 5x^2 + 4 = 0\"\"\"\n",
+    "\n",
+    "result = chat_with_traces(problem, system=custom_system)\n",
+    "\n",
+    "print(\"=== Thinking Traces ===\")\n",
+    "print(result[\"thinking\"][:1500])\n",
+    "print(\"\\n=== Final Answer ===\")\n",
+    "print(result[\"answer\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-section8",
+   "metadata": {},
+   "source": [
+    "## 8. Multi-Step Reasoning: Real-World Scenario\n",
+    "\n",
+    "Let's test the model with a more realistic scenario that requires combining multiple types of reasoning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-real-world",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scenario_prompt = \"\"\"A company is planning to launch a new product. Here are the constraints:\n",
+    "\n",
+    "- The development team can work on at most 2 features per sprint (2 weeks).\n",
+    "- Feature A takes 1 sprint and has no dependencies.\n",
+    "- Feature B takes 2 sprints and depends on Feature A.\n",
+    "- Feature C takes 1 sprint and has no dependencies.\n",
+    "- Feature D takes 1 sprint and depends on both B and C.\n",
+    "- Feature E takes 2 sprints and depends on D.\n",
+    "- Testing takes 1 sprint after all features are complete.\n",
+    "- The team has a hard deadline of 12 weeks from now.\n",
+    "\n",
+    "Questions:\n",
+    "1. What is the critical path?\n",
+    "2. What is the minimum number of sprints needed?\n",
+    "3. Can the team meet the 12-week deadline? If not, what would you recommend?\n",
+    "4. Draw a simple dependency graph using text/ASCII.\n",
+    "\n",
+    "Think through this carefully, considering parallel execution where possible.\"\"\"\n",
+    "\n",
+    "result = chat_with_traces(scenario_prompt)\n",
+    "\n",
+    "print(\"=== Thinking Traces ===\")\n",
+    "print(result[\"thinking\"][:2000])\n",
+    "print(\"\\n=== Final Answer ===\")\n",
+    "print(result[\"answer\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-conclusion",
+   "metadata": {},
+   "source": [
+    "## Best Practices for Reasoning with Mistral\n",
+    "\n",
+    "### Model Selection\n",
+    "- Use `magistral-medium-latest` for complex problems requiring deep reasoning\n",
+    "- Use `magistral-small-latest` for simpler reasoning tasks with lower latency\n",
+    "- Use `mistral-large-latest` when reasoning is not the primary requirement\n",
+    "\n",
+    "### Prompting Tips\n",
+    "- **Be explicit about reasoning**: Phrases like \"Think step by step\" or \"Show your work\" can improve output structure\n",
+    "- **Break down complex problems**: Provide clear structure with numbered sub-questions\n",
+    "- **Use custom system prompts** when you need the model to follow a specific reasoning framework\n",
+    "- **Leverage thinking traces**: Parse the `thinking` blocks to understand the model's reasoning process, useful for debugging and validation\n",
+    "\n",
+    "### Understanding the Output\n",
+    "- Thinking traces (`type: \"thinking\"`) show the model's internal reasoning\n",
+    "- Final answers (`type: \"text\"`) contain the polished response\n",
+    "- The `prompt_mode` parameter controls whether the default reasoning system prompt is used\n",
+    "\n",
+    "### When to Use Reasoning Models\n",
+    "- Mathematical problems requiring multiple steps\n",
+    "- Logic puzzles and constraint satisfaction\n",
+    "- Code analysis and debugging\n",
+    "- Complex planning and scheduling\n",
+    "- Any task where showing work improves accuracy\n",
+    "\n",
+    "### Resources\n",
+    "- [Mistral Reasoning Documentation](https://docs.mistral.ai/capabilities/reasoning/)\n",
+    "- [Mistral API Reference](https://docs.mistral.ai/api/)\n",
+    "- [Mistral Cookbook](https://github.com/mistralai/cookbook)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbformat_minor": 5,
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Add a new cookbook notebook demonstrating Mistral's **reasoning capabilities** using the Magistral models (`magistral-small-latest`, `magistral-medium-latest`).

The cookbook currently has no notebook dedicated to reasoning or chain-of-thought prompting. This notebook fills that gap by providing practical, runnable examples.

### What's included

- **Thinking traces parsing**: How to separate `thinking` blocks from `text` blocks in Magistral responses
- **Chain-of-thought prompting**: Explicit CoT instructions for complex multi-step problems
- **Mathematical reasoning**: Train meeting problems, algebraic equations
- **Logical deduction**: Classic truth-teller/liar puzzles
- **Code analysis**: Bug detection and correction with step-by-step reasoning
- **Reasoning vs. standard comparison**: Side-by-side comparison of `magistral-medium-latest` vs `mistral-large-latest` on the same problem
- **`prompt_mode` parameter**: How to control reasoning behavior with custom system prompts
- **Real-world scenario**: Project planning with critical path analysis

### Technical details

- Uses `mistralai==1.12.4` (pinned version)
- No hardcoded API keys (`os.environ.get("MISTRAL_API_KEY")`)
- Runnable on Google Colab (badge included)
- Clean outputs (no cell outputs committed)
- Follows existing cookbook format (modeled after `prompting_capabilities.ipynb`)

### Files changed

- `mistral/reasoning/reasoning_capabilities.ipynb` (new)
- `README.md` (added entry to Main Notebooks table)