### PR TITLE
feat(notebook): add agents handoffs cookbook with multi-agent routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [intent_classification.ipynb](mistral/classifier_factory/intent_classification.ipynb) | fine-tuning, classifier | Fine-tuning a classifier for intent classification. |
 | [moderation_classifier.ipynb](mistral/classifier_factory/moderation_classifier.ipynb) | fine-tuning, classifier | Fine-tuning a classifier for moderation. |
 | [pixtral_finetune_on_satellite_data.ipynb](mistral/fine_tune/pixtral_finetune_on_satellite_data.ipynb) | fine-tuning, image processing, batch | Fine-tuning a Pixtral-12B for satellite images classification. |
+| [agents_handoffs.ipynb](mistral/agents/agents_api/agents_handoffs.ipynb) | agents, handoffs, multi-agent | Build multi-agent systems with automatic and manual handoff routing |
 
 
 

--- a/mistral/agents/agents_api/agents_handoffs.ipynb
+++ b/mistral/agents/agents_api/agents_handoffs.ipynb
@@ -1,0 +1,497 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Agent Handoffs with the Mistral Agents API\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/mistralai/cookbook/blob/main/mistral/agents/agents_api/agents_handoffs.ipynb)\n",
+    "\n",
+    "This notebook demonstrates how to build multi-agent systems using Mistral's Agents API with automatic and manual handoff capabilities. Handoffs allow a **triage agent** to delegate tasks to **specialized agents**, enabling modular and scalable agent architectures.\n",
+    "\n",
+    "**Author**: [abdelhadi703](https://github.com/abdelhadi703)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the Mistral AI SDK and set up the client."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q \"mistralai>=1.6.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from getpass import getpass\n",
+    "from mistralai import Mistral\n",
+    "\n",
+    "api_key = os.environ.get(\"MISTRAL_API_KEY\") or getpass(\"Enter your Mistral API key: \")\n",
+    "client = Mistral(api_key=api_key)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Concepts: What Are Agent Handoffs?\n",
+    "\n",
+    "A **handoff** lets one agent delegate a task to another agent. This is useful when:\n",
+    "\n",
+    "- Different agents specialize in different domains (coding, research, customer support).\n",
+    "- A **triage agent** acts as a router, analyzing the user's query and forwarding it to the most relevant specialist.\n",
+    "- You want to build a **multi-agent network** where agents can call each other.\n",
+    "\n",
+    "Mistral supports two handoff execution modes:\n",
+    "\n",
+    "| Mode | Parameter | Behavior |\n",
+    "|------|-----------|----------|\n",
+    "| **Server** (default) | `handoff_execution=\"server\"` | The server automatically routes the conversation to the target agent and returns the final response. |\n",
+    "| **Client** | `handoff_execution=\"client\"` | The server returns a handoff event, and your code decides how to proceed. |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Creating Agents with Handoffs\n",
+    "\n",
+    "Let's create three agents:\n",
+    "- A **Code Expert** that uses the code interpreter tool.\n",
+    "- A **Research Expert** that uses web search.\n",
+    "- A **Triage Agent** that routes queries to the right specialist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Agent specialized in coding tasks\n",
+    "code_agent = client.beta.agents.create(\n",
+    "    model=\"mistral-medium-latest\",\n",
+    "    name=\"Code Expert\",\n",
+    "    description=\"Agent specialized in writing, reviewing, and debugging code.\",\n",
+    "    instructions=\"You are a coding expert. Write clean, well-commented code. Use the code interpreter to run and validate your solutions.\",\n",
+    "    tools=[{\"type\": \"code_interpreter\"}],\n",
+    ")\n",
+    "print(f\"Code Expert agent created: {code_agent.id}\")\n",
+    "\n",
+    "# Agent specialized in web research\n",
+    "research_agent = client.beta.agents.create(\n",
+    "    model=\"mistral-medium-latest\",\n",
+    "    name=\"Research Expert\",\n",
+    "    description=\"Agent specialized in searching the web for up-to-date information.\",\n",
+    "    instructions=\"You are a research expert. Use web search to find accurate, recent information. Always cite your sources.\",\n",
+    "    tools=[{\"type\": \"web_search\"}],\n",
+    ")\n",
+    "print(f\"Research Expert agent created: {research_agent.id}\")\n",
+    "\n",
+    "# Triage agent that routes to specialists\n",
+    "triage_agent = client.beta.agents.create(\n",
+    "    model=\"mistral-medium-latest\",\n",
+    "    name=\"Triage Agent\",\n",
+    "    description=\"Agent that routes user queries to the appropriate specialist.\",\n",
+    "    instructions=(\n",
+    "        \"You are a triage agent. Analyze the user's query and route it to the right specialist:\\n\"\n",
+    "        \"- For coding questions (write code, debug, explain code), hand off to Code Expert.\\n\"\n",
+    "        \"- For research questions (current events, factual lookups), hand off to Research Expert.\\n\"\n",
+    "        \"- For general questions, answer directly.\"\n",
+    "    ),\n",
+    "    handoffs=[code_agent.id, research_agent.id],\n",
+    ")\n",
+    "print(f\"Triage Agent created: {triage_agent.id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Server Mode: Automatic Handoff Execution\n",
+    "\n",
+    "In **server mode** (`handoff_execution=\"server\"`, the default), the Mistral server automatically executes the handoff. The triage agent decides which specialist to call, and the server handles the routing transparently.\n",
+    "\n",
+    "We use `start_stream` to see the handoff events in real time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mistralai import (\n",
+    "    AgentHandoffStartedEvent,\n",
+    "    AgentHandoffDoneEvent,\n",
+    "    MessageOutputEvent,\n",
+    "    ToolExecutionStartedEvent,\n",
+    "    ToolExecutionDoneEvent,\n",
+    "    ResponseStartedEvent,\n",
+    "    ResponseDoneEvent,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def run_agent_stream(agent_id, user_input, handoff_execution=\"server\"):\n",
+    "    \"\"\"Run an agent with streaming and display handoff events.\"\"\"\n",
+    "    print(f\"User: {user_input}\\n\")\n",
+    "    conversation_id = None\n",
+    "\n",
+    "    response = client.beta.conversations.start_stream(\n",
+    "        agent_id=agent_id,\n",
+    "        inputs=user_input,\n",
+    "        handoff_execution=handoff_execution,\n",
+    "    )\n",
+    "\n",
+    "    with response as event_stream:\n",
+    "        for event in event_stream:\n",
+    "            match event.data:\n",
+    "                case ResponseStartedEvent():\n",
+    "                    conversation_id = event.data.conversation_id\n",
+    "                case AgentHandoffStartedEvent():\n",
+    "                    print(f\"\\n>> Handoff started (leaving: {event.data.previous_agent_name})\")\n",
+    "                case AgentHandoffDoneEvent():\n",
+    "                    print(f\">> Handoff done (entering: {event.data.next_agent_name})\\n\")\n",
+    "                case ToolExecutionStartedEvent():\n",
+    "                    print(f\"  [Tool: {event.data.name}]\")\n",
+    "                case MessageOutputEvent():\n",
+    "                    if isinstance(event.data.content, str):\n",
+    "                        print(event.data.content, end=\"\")\n",
+    "\n",
+    "    print(\"\\n\")\n",
+    "    return conversation_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This query should be routed to the Code Expert\n",
+    "conv_id = run_agent_stream(\n",
+    "    triage_agent.id,\n",
+    "    \"Write a Python function to calculate the nth Fibonacci number using memoization.\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This query should be routed to the Research Expert\n",
+    "conv_id_research = run_agent_stream(\n",
+    "    triage_agent.id,\n",
+    "    \"What were the key announcements at the latest Mistral AI product launch?\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Client Mode: Manual Handoff Control\n",
+    "\n",
+    "In **client mode** (`handoff_execution=\"client\"`), the server returns a handoff event instead of automatically routing. Your application code then decides how to handle it — useful for adding custom logic, logging, or approval steps before the handoff proceeds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"User: Explain how quicksort works and find its current Wikipedia page.\\n\")\n",
+    "\n",
+    "response = client.beta.conversations.start_stream(\n",
+    "    agent_id=triage_agent.id,\n",
+    "    inputs=\"Explain how quicksort works and find its current Wikipedia page.\",\n",
+    "    handoff_execution=\"client\",\n",
+    ")\n",
+    "\n",
+    "conversation_id = None\n",
+    "handoff_target_id = None\n",
+    "handoff_target_name = None\n",
+    "\n",
+    "with response as event_stream:\n",
+    "    for event in event_stream:\n",
+    "        match event.data:\n",
+    "            case ResponseStartedEvent():\n",
+    "                conversation_id = event.data.conversation_id\n",
+    "            case AgentHandoffStartedEvent():\n",
+    "                print(f\">> Handoff requested (leaving: {event.data.previous_agent_name})\")\n",
+    "            case AgentHandoffDoneEvent():\n",
+    "                handoff_target_id = event.data.next_agent_id\n",
+    "                handoff_target_name = event.data.next_agent_name\n",
+    "                print(f\">> Target agent: {handoff_target_name} ({handoff_target_id})\")\n",
+    "            case MessageOutputEvent():\n",
+    "                if isinstance(event.data.content, str):\n",
+    "                    print(event.data.content, end=\"\")\n",
+    "\n",
+    "print(f\"\\n\\nConversation ID: {conversation_id}\")\n",
+    "print(f\"Handoff target: {handoff_target_name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now we manually continue the conversation with the target agent\n",
+    "if handoff_target_id and conversation_id:\n",
+    "    print(f\"Continuing conversation with {handoff_target_name}...\\n\")\n",
+    "\n",
+    "    response = client.beta.conversations.append_stream(\n",
+    "        conversation_id=conversation_id,\n",
+    "        inputs=\"Please proceed with the task.\",\n",
+    "        handoff_execution=\"server\",\n",
+    "    )\n",
+    "\n",
+    "    with response as event_stream:\n",
+    "        for event in event_stream:\n",
+    "            match event.data:\n",
+    "                case AgentHandoffDoneEvent():\n",
+    "                    print(f\"\\n>> Handed off to: {event.data.next_agent_name}\\n\")\n",
+    "                case ToolExecutionStartedEvent():\n",
+    "                    print(f\"  [Tool: {event.data.name}]\")\n",
+    "                case MessageOutputEvent():\n",
+    "                    if isinstance(event.data.content, str):\n",
+    "                        print(event.data.content, end=\"\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Multi-Agent Network: Travel Assistant Pattern\n",
+    "\n",
+    "A more advanced pattern involves creating a **network of agents** where each specialist can hand off to others. This mirrors the `travel_assistant` example in the cookbook.\n",
+    "\n",
+    "We'll create:\n",
+    "- A **Travel Triage** agent that routes user queries.\n",
+    "- A **Flights** agent for flight-related queries.\n",
+    "- A **Hotels** agent for accommodation queries.\n",
+    "- An **Activities** agent for local activities and events."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create specialized travel agents\n",
+    "flights_agent = client.beta.agents.create(\n",
+    "    model=\"mistral-medium-latest\",\n",
+    "    name=\"Flights Agent\",\n",
+    "    description=\"Agent specialized in finding and recommending flights.\",\n",
+    "    instructions=(\n",
+    "        \"You are a flights specialist. Help users find flights, compare options, \"\n",
+    "        \"and provide booking advice. Use web search to find current flight information.\"\n",
+    "    ),\n",
+    "    tools=[{\"type\": \"web_search\"}],\n",
+    ")\n",
+    "\n",
+    "hotels_agent = client.beta.agents.create(\n",
+    "    model=\"mistral-medium-latest\",\n",
+    "    name=\"Hotels Agent\",\n",
+    "    description=\"Agent specialized in finding and recommending hotels.\",\n",
+    "    instructions=(\n",
+    "        \"You are a hotels specialist. Help users find accommodations, compare hotels, \"\n",
+    "        \"and provide booking advice. Use web search to find current hotel information.\"\n",
+    "    ),\n",
+    "    tools=[{\"type\": \"web_search\"}],\n",
+    ")\n",
+    "\n",
+    "activities_agent = client.beta.agents.create(\n",
+    "    model=\"mistral-medium-latest\",\n",
+    "    name=\"Activities Agent\",\n",
+    "    description=\"Agent specialized in finding local activities, tours, and events.\",\n",
+    "    instructions=(\n",
+    "        \"You are an activities and events specialist. Help users discover things to do, \"\n",
+    "        \"local tours, restaurants, and cultural events. Use web search to find current information.\"\n",
+    "    ),\n",
+    "    tools=[{\"type\": \"web_search\"}],\n",
+    ")\n",
+    "\n",
+    "# Create the travel triage agent\n",
+    "travel_triage = client.beta.agents.create(\n",
+    "    model=\"mistral-medium-latest\",\n",
+    "    name=\"Travel Triage\",\n",
+    "    description=\"Main travel assistant that routes queries to specialists.\",\n",
+    "    instructions=(\n",
+    "        \"You are a travel assistant. Route user queries to the right specialist:\\n\"\n",
+    "        \"- Flight questions -> Flights Agent\\n\"\n",
+    "        \"- Hotel/accommodation questions -> Hotels Agent\\n\"\n",
+    "        \"- Activities/events/restaurants -> Activities Agent\\n\"\n",
+    "        \"- General travel questions -> answer directly.\"\n",
+    "    ),\n",
+    "    handoffs=[flights_agent.id, hotels_agent.id, activities_agent.id],\n",
+    ")\n",
+    "\n",
+    "print(\"Travel agents created!\")\n",
+    "print(f\"  Travel Triage: {travel_triage.id}\")\n",
+    "print(f\"  Flights Agent: {flights_agent.id}\")\n",
+    "print(f\"  Hotels Agent:  {hotels_agent.id}\")\n",
+    "print(f\"  Activities Agent: {activities_agent.id}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up cross-handoffs so specialists can route to each other\n",
+    "client.beta.agents.update(agent_id=flights_agent.id, handoffs=[hotels_agent.id, activities_agent.id])\n",
+    "client.beta.agents.update(agent_id=hotels_agent.id, handoffs=[flights_agent.id, activities_agent.id])\n",
+    "client.beta.agents.update(agent_id=activities_agent.id, handoffs=[flights_agent.id, hotels_agent.id])\n",
+    "\n",
+    "print(\"Cross-handoffs configured!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test the travel network\n",
+    "conv_travel = run_agent_stream(\n",
+    "    travel_triage.id,\n",
+    "    \"I'm planning a trip to Tokyo next month. Can you find some popular activities and local food tours?\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Inspecting Conversation History\n",
+    "\n",
+    "After a conversation with handoffs, you can use `get_history()` to inspect the full sequence of events, including `AgentHandoffEntry` entries that show which agents were involved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mistralai import AgentHandoffEntry\n",
+    "\n",
+    "if conv_travel:\n",
+    "    history = client.beta.conversations.get_history(conversation_id=conv_travel)\n",
+    "\n",
+    "    print(f\"Conversation {conv_travel}\")\n",
+    "    print(f\"Total entries: {len(history.entries)}\\n\")\n",
+    "\n",
+    "    for i, entry in enumerate(history.entries):\n",
+    "        entry_type = entry.type if hasattr(entry, \"type\") else type(entry).__name__\n",
+    "        print(f\"Entry {i}: type={entry_type}\")\n",
+    "\n",
+    "        if isinstance(entry, AgentHandoffEntry):\n",
+    "            print(f\"  Handoff: {entry.previous_agent_name} -> {entry.next_agent_name}\")\n",
+    "        elif hasattr(entry, \"role\"):\n",
+    "            content_preview = \"\"\n",
+    "            if hasattr(entry, \"content\") and isinstance(entry.content, str):\n",
+    "                content_preview = entry.content[:100] + \"...\" if len(entry.content) > 100 else entry.content\n",
+    "            elif hasattr(entry, \"content\") and isinstance(entry.content, list):\n",
+    "                for chunk in entry.content:\n",
+    "                    if hasattr(chunk, \"text\"):\n",
+    "                        content_preview = chunk.text[:100] + \"...\"\n",
+    "                        break\n",
+    "            print(f\"  Role: {entry.role}, Content: {content_preview}\")\n",
+    "        print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Cleanup\n",
+    "\n",
+    "Delete all agents created during this notebook to keep your account tidy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agents_to_delete = [\n",
+    "    (\"Triage Agent\", triage_agent),\n",
+    "    (\"Code Expert\", code_agent),\n",
+    "    (\"Research Expert\", research_agent),\n",
+    "    (\"Travel Triage\", travel_triage),\n",
+    "    (\"Flights Agent\", flights_agent),\n",
+    "    (\"Hotels Agent\", hotels_agent),\n",
+    "    (\"Activities Agent\", activities_agent),\n",
+    "]\n",
+    "\n",
+    "for name, agent in agents_to_delete:\n",
+    "    try:\n",
+    "        client.beta.agents.delete(agent_id=agent.id)\n",
+    "        print(f\"Deleted {name} ({agent.id})\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"Failed to delete {name}: {e}\")\n",
+    "\n",
+    "print(\"\\nCleanup complete!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Best Practices\n",
+    "\n",
+    "1. **Write clear `description` fields.** The triage agent uses descriptions to decide which specialist to route to. Be specific about each agent's capabilities.\n",
+    "\n",
+    "2. **Use `instructions` to define behavior.** Instructions act as the system prompt. Include guidance on when to answer directly vs. when to hand off.\n",
+    "\n",
+    "3. **Use `handoffs` at creation time or via `update`.** You can pass `handoffs` directly to `agents.create()`, or configure them later with `agents.update()`. The latter is necessary for circular handoff networks.\n",
+    "\n",
+    "4. **Choose the right execution mode:**\n",
+    "   - **Server mode** is simpler and works well for straightforward routing.\n",
+    "   - **Client mode** gives you control over the routing decision, useful for logging, approval workflows, or custom routing logic.\n",
+    "\n",
+    "5. **Clean up agents.** Agents persist on your account. Always delete them when they are no longer needed.\n",
+    "\n",
+    "6. **Inspect history for debugging.** Use `get_history()` to see the full conversation flow, including which agents handled which parts."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Description

Adds a Jupyter notebook demonstrating Mistral's Agents API handoff capabilities. The cookbook currently has Chainlit-based agent examples (travel_assistant, food_diet_companion) but no `.ipynb` notebook covering handoffs — this fills that gap.

## Content

- **Simple handoff**: Triage agent routing queries to a Code Expert (code_interpreter) and a Research Expert (web_search)
- **Server mode**: Automatic handoff execution with real-time SSE event handling (`AgentHandoffStartedEvent`, `AgentHandoffDoneEvent`)
- **Client mode**: Manual handoff routing with `handoff_execution="client"` for custom control flow
- **Multi-agent network**: Travel assistant pattern with 4 agents (triage + flights + hotels + activities) and cross-handoffs via `agents.update()`
- **Conversation history**: Inspecting `AgentHandoffEntry` via `get_history()`
- **Cleanup**: Proper agent deletion

## Conventions

- API key via `os.environ` with `getpass` fallback (no hardcoded keys)
- Pinned SDK version (`mistralai>=1.6.0`)
- Colab badge at the top
- Clean cell outputs
- All API calls verified against the `mistralai` Python SDK v1.10.0 signatures

## Testing

- [x] Notebook JSON is valid
- [x] All API method names and parameters verified against SDK source
- [x] Event types (`AgentHandoffStartedEvent`, `AgentHandoffDoneEvent`, `MessageOutputEvent`) match SDK definitions
- [ ] End-to-end run with API key (requires live API access)