### PR TITLE
feat(notebook): add GraphRAG knowledge extraction from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [quickstart.ipynb](quickstart.ipynb)                                           | chat, embeddings             | Basic quickstart with chat and embeddings with Mistral AI API                    |
 | [prompting_capabilities.ipynb](mistral/prompting/prompting_capabilities.ipynb) | prompting                    | Write prompts for classification, summarization, personalization, and evaluation |
 | [basic_RAG.ipynb](mistral/rag/basic_RAG.ipynb)                                 | RAG                          | RAG from scratch with Mistral AI API                                             |
+| [graphrag_knowledge_extraction.ipynb](mistral/rag/graphrag_knowledge_extraction.ipynb) | RAG, knowledge graph, structured outputs | Build GraphRAG from scratch with Mistral: entity extraction, knowledge graph, and hybrid retrieval |
 | [embeddings.ipynb](mistral/embeddings/embeddings.ipynb)                        | embeddings                   | Use Mistral embeddings API for classification and clustering                     |                                           |
 | [function_calling.ipynb](mistral/function_calling/function_calling.ipynb)      | function calling             | Use Mistral API for function calling                                             |
 | [text_to_SQL.ipynb](mistral/function_calling/text_to_SQL.ipynb)      | function calling             | Use Mistral API for function calling on a multi tables text to SQL usecase                                             |

--- a/mistral/rag/graphrag_knowledge_extraction.ipynb
+++ b/mistral/rag/graphrag_knowledge_extraction.ipynb
@@ -1,0 +1,504 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GraphRAG: Knowledge Graph-Enhanced RAG with Mistral AI\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/mistralai/cookbook/blob/main/mistral/rag/graphrag_knowledge_extraction.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "This notebook demonstrates how to build a **Graph RAG** pipeline from scratch using only the Mistral AI SDK. Unlike traditional vector-based RAG, GraphRAG extracts entities and relationships from documents to build a knowledge graph, enabling multi-hop reasoning and more precise retrieval.\n",
+    "\n",
+    "**What you'll learn:**\n",
+    "- Extract entities and relationships using Mistral Large's structured outputs\n",
+    "- Build a knowledge graph with NetworkX (no external DB required)\n",
+    "- Combine vector similarity search (FAISS) with graph traversal for hybrid retrieval\n",
+    "- Compare standard RAG vs GraphRAG on multi-hop questions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install mistralai==1.5.0 networkx==3.4.2 faiss-cpu==1.9.0.post1 matplotlib==3.9.4 numpy==1.26.4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup & API Key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import numpy as np\n",
+    "import networkx as nx\n",
+    "import matplotlib.pyplot as plt\n",
+    "from typing import List, Optional\n",
+    "from pydantic import BaseModel, Field\n",
+    "from getpass import getpass\n",
+    "from mistralai import Mistral\n",
+    "import faiss\n",
+    "\n",
+    "api_key = getpass(\"Type your API Key\")\n",
+    "client = Mistral(api_key=api_key)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Sample Knowledge Base\n",
+    "\n",
+    "We use a set of interconnected paragraphs about a fictional technology company to demonstrate multi-hop reasoning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "documents = [\n",
+    "    \"QuantumCore Technologies was founded in 2019 by Dr. Elena Martinez, a former researcher at MIT's CSAIL lab. The company is headquartered in San Francisco and specializes in quantum-enhanced machine learning algorithms.\",\n",
+    "    \"Dr. Elena Martinez previously collaborated with Prof. James Liu at Stanford on quantum error correction protocols. Prof. Liu later joined QuantumCore's advisory board in 2021.\",\n",
+    "    \"QuantumCore's flagship product, QML-Engine v3.0, was launched in March 2024. It integrates quantum computing primitives with classical deep learning frameworks like PyTorch and JAX.\",\n",
+    "    \"In September 2024, QuantumCore announced a partnership with NovaStar Pharma to apply quantum ML to drug discovery. NovaStar's CEO, Dr. Raj Patel, called it 'a paradigm shift in computational biology.'\",\n",
+    "    \"NovaStar Pharma, based in Boston, was founded in 2015 by Dr. Raj Patel and Dr. Sarah Kim. The company focuses on AI-driven drug discovery and has 3 drugs in Phase II clinical trials.\",\n",
+    "    \"QuantumCore raised $150M in Series C funding led by Horizon Ventures in January 2025. The valuation reached $2.1B, making it one of the most valuable quantum computing startups.\",\n",
+    "    \"Horizon Ventures, based in Hong Kong, is known for backing deep tech companies. Their portfolio includes 12 quantum computing and 8 AI companies across Asia and North America.\",\n",
+    "    \"Dr. Sarah Kim left NovaStar in 2023 to join QuantumCore as VP of Life Sciences. She now leads the drug discovery division that partners with her former company.\"\n",
+    "]\n",
+    "\n",
+    "print(f\"Knowledge base: {len(documents)} documents\")\n",
+    "for i, doc in enumerate(documents):\n",
+    "    print(f\"\\n[Doc {i}]: {doc[:80]}...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Entity & Relationship Extraction with Structured Outputs\n",
+    "\n",
+    "We define Pydantic models for entities and relationships, then use Mistral Large to extract them from each document."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Entity(BaseModel):\n",
+    "    \"\"\"An entity extracted from text.\"\"\"\n",
+    "    name: str = Field(description=\"The canonical name of the entity\")\n",
+    "    type: str = Field(description=\"Entity type: PERSON, ORGANIZATION, PRODUCT, LOCATION, EVENT, or DATE\")\n",
+    "    description: str = Field(description=\"Brief description of the entity based on context\")\n",
+    "\n",
+    "class Relationship(BaseModel):\n",
+    "    \"\"\"A relationship between two entities.\"\"\"\n",
+    "    source: str = Field(description=\"Name of the source entity\")\n",
+    "    target: str = Field(description=\"Name of the target entity\")\n",
+    "    type: str = Field(description=\"Relationship type: FOUNDED_BY, WORKS_AT, PARTNER_OF, INVESTED_IN, LOCATED_IN, CREATED, or RELATED_TO\")\n",
+    "    description: str = Field(description=\"Brief description of the relationship\")\n",
+    "\n",
+    "class ExtractionResult(BaseModel):\n",
+    "    \"\"\"Complete extraction result from a document.\"\"\"\n",
+    "    entities: List[Entity] = Field(description=\"List of extracted entities\")\n",
+    "    relationships: List[Relationship] = Field(description=\"List of extracted relationships\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_from_document(doc: str, doc_id: int) -> ExtractionResult:\n",
+    "    \"\"\"Extract entities and relationships from a single document using Mistral Large.\"\"\"\n",
+    "    \n",
+    "    prompt = f\"\"\"Analyze the following text and extract all entities and their relationships.\n",
+    "\n",
+    "Text: {doc}\n",
+    "\n",
+    "Extract:\n",
+    "1. All named entities (people, organizations, products, locations, dates)\n",
+    "2. All relationships between entities\n",
+    "\n",
+    "Be thorough but precise. Only extract what is explicitly stated or directly implied.\"\"\"\n",
+    "\n",
+    "    response = client.chat.complete(\n",
+    "        model=\"mistral-large-latest\",\n",
+    "        messages=[{\"role\": \"user\", \"content\": prompt}],\n",
+    "        response_format={\n",
+    "            \"type\": \"json_schema\",\n",
+    "            \"json_schema\": {\n",
+    "                \"name\": \"extraction\",\n",
+    "                \"schema\": ExtractionResult.model_json_schema()\n",
+    "            }\n",
+    "        }\n",
+    "    )\n",
+    "    \n",
+    "    result = ExtractionResult.model_validate_json(response.choices[0].message.content)\n",
+    "    print(f\"[Doc {doc_id}] Extracted {len(result.entities)} entities, {len(result.relationships)} relationships\")\n",
+    "    return result\n",
+    "\n",
+    "# Extract from all documents\n",
+    "all_extractions = []\n",
+    "for i, doc in enumerate(documents):\n",
+    "    extraction = extract_from_document(doc, i)\n",
+    "    all_extractions.append(extraction)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Build the Knowledge Graph\n",
+    "\n",
+    "We merge all extracted entities and relationships into a single NetworkX directed graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "G = nx.DiGraph()\n",
+    "\n",
+    "entity_registry = {}\n",
+    "for extraction in all_extractions:\n",
+    "    for entity in extraction.entities:\n",
+    "        name = entity.name.strip()\n",
+    "        if name not in entity_registry:\n",
+    "            entity_registry[name] = entity\n",
+    "            G.add_node(name, type=entity.type, description=entity.description)\n",
+    "\n",
+    "for extraction in all_extractions:\n",
+    "    for rel in extraction.relationships:\n",
+    "        source = rel.source.strip()\n",
+    "        target = rel.target.strip()\n",
+    "        if source in entity_registry and target in entity_registry:\n",
+    "            G.add_edge(source, target, type=rel.type, description=rel.description)\n",
+    "\n",
+    "print(f\"Knowledge Graph: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges\")\n",
+    "\n",
+    "# Count entity types\n",
+    "from collections import Counter\n",
+    "type_counts = Counter(d['type'] for _, d in G.nodes(data=True))\n",
+    "print(f\"Entity types: {dict(type_counts)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Visualize the Knowledge Graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(14, 10))\n",
+    "\n",
+    "# Color nodes by type\n",
+    "color_map = {\n",
+    "    \"PERSON\": \"#FF6B6B\",\n",
+    "    \"ORGANIZATION\": \"#4ECDC4\",\n",
+    "    \"PRODUCT\": \"#45B7D1\",\n",
+    "    \"LOCATION\": \"#96CEB4\",\n",
+    "    \"EVENT\": \"#FFEAA7\",\n",
+    "    \"DATE\": \"#DDA0DD\"\n",
+    "}\n",
+    "node_colors = [color_map.get(G.nodes[n].get(\"type\", \"\"), \"#CCCCCC\") for n in G.nodes()]\n",
+    "\n",
+    "pos = nx.spring_layout(G, k=2, iterations=50, seed=42)\n",
+    "nx.draw_networkx_nodes(G, pos, node_color=node_colors, node_size=800, alpha=0.9)\n",
+    "nx.draw_networkx_labels(G, pos, font_size=7, font_weight=\"bold\")\n",
+    "nx.draw_networkx_edges(G, pos, edge_color=\"#888888\", arrows=True, arrowsize=15, alpha=0.6)\n",
+    "\n",
+    "# Edge labels\n",
+    "edge_labels = {(u, v): d[\"type\"] for u, v, d in G.edges(data=True)}\n",
+    "nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels, font_size=6, alpha=0.7)\n",
+    "\n",
+    "# Legend\n",
+    "legend_elements = [plt.Line2D([0], [0], marker='o', color='w', markerfacecolor=c, markersize=10, label=t) \n",
+    "                   for t, c in color_map.items() if any(G.nodes[n].get(\"type\") == t for n in G.nodes())]\n",
+    "plt.legend(handles=legend_elements, loc=\"upper left\", fontsize=9)\n",
+    "\n",
+    "plt.title(\"Knowledge Graph \\u2014 Extracted with Mistral Large\", fontsize=14)\n",
+    "plt.axis(\"off\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Document Embeddings with Mistral Embed\n",
+    "\n",
+    "We create vector embeddings for each document using Mistral's embedding model, stored in a FAISS index for similarity search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_embeddings(texts: List[str]) -> np.ndarray:\n",
+    "    \"\"\"Get embeddings for a list of texts using Mistral Embed.\"\"\"\n",
+    "    response = client.embeddings.create(\n",
+    "        model=\"mistral-embed\",\n",
+    "        inputs=texts\n",
+    "    )\n",
+    "    return np.array([item.embedding for item in response.data], dtype=\"float32\")\n",
+    "\n",
+    "# Embed all documents\n",
+    "doc_embeddings = get_embeddings(documents)\n",
+    "print(f\"Embeddings shape: {doc_embeddings.shape}\")  # (8, 1024)\n",
+    "\n",
+    "# Build FAISS index\n",
+    "dimension = doc_embeddings.shape[1]\n",
+    "index = faiss.IndexFlatL2(dimension)\n",
+    "index.add(doc_embeddings)\n",
+    "print(f\"FAISS index: {index.ntotal} vectors, dimension {dimension}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Hybrid Retrieval \\u2014 Vector Search + Graph Traversal\n",
+    "\n",
+    "This is the core of GraphRAG: we combine FAISS vector similarity with knowledge graph traversal.\n",
+    "\n",
+    "1. **Vector retrieval**: Find top-k similar documents via FAISS\n",
+    "2. **Entity extraction**: Extract entities from the query\n",
+    "3. **Graph traversal**: Follow relationships from query entities (BFS, 2 hops)\n",
+    "4. **Merge & deduplicate**: Combine both document sets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def vector_retrieval(query: str, k: int = 3) -> List[int]:\n",
+    "    \"\"\"Retrieve top-k documents by vector similarity.\"\"\"\n",
+    "    query_embedding = get_embeddings([query])\n",
+    "    distances, indices = index.search(query_embedding, k)\n",
+    "    return indices[0].tolist()\n",
+    "\n",
+    "def extract_query_entities(query: str) -> List[str]:\n",
+    "    \"\"\"Extract entity names from the query using Mistral.\"\"\"\n",
+    "    response = client.chat.complete(\n",
+    "        model=\"mistral-large-latest\",\n",
+    "        messages=[{\"role\": \"user\", \"content\": f\"Extract all entity names from this query. Return a JSON list of strings.\\n\\nQuery: {query}\"}],\n",
+    "        response_format={\"type\": \"json_object\"}\n",
+    "    )\n",
+    "    data = json.loads(response.choices[0].message.content)\n",
+    "    # Handle various response formats\n",
+    "    if isinstance(data, list):\n",
+    "        return data\n",
+    "    if isinstance(data, dict):\n",
+    "        for key in [\"entities\", \"names\", \"entity_names\"]:\n",
+    "            if key in data and isinstance(data[key], list):\n",
+    "                return data[key]\n",
+    "    return []\n",
+    "\n",
+    "def graph_retrieval(query_entities: List[str], max_hops: int = 2) -> set:\n",
+    "    \"\"\"Retrieve document indices by traversing the knowledge graph from query entities.\"\"\"\n",
+    "    relevant_nodes = set()\n",
+    "    \n",
+    "    # Find matching nodes in the graph\n",
+    "    for entity in query_entities:\n",
+    "        for node in G.nodes():\n",
+    "            if entity.lower() in node.lower() or node.lower() in entity.lower():\n",
+    "                relevant_nodes.add(node)\n",
+    "                # BFS traversal up to max_hops\n",
+    "                for hop in range(1, max_hops + 1):\n",
+    "                    neighbors = set()\n",
+    "                    for n in list(relevant_nodes):\n",
+    "                        neighbors.update(G.successors(n))\n",
+    "                        neighbors.update(G.predecessors(n))\n",
+    "                    relevant_nodes.update(neighbors)\n",
+    "    \n",
+    "    # Map nodes back to documents that mention them\n",
+    "    relevant_doc_indices = set()\n",
+    "    for idx, doc in enumerate(documents):\n",
+    "        for node in relevant_nodes:\n",
+    "            if node.lower() in doc.lower():\n",
+    "                relevant_doc_indices.add(idx)\n",
+    "    \n",
+    "    return relevant_doc_indices\n",
+    "\n",
+    "def hybrid_retrieval(query: str, k_vector: int = 3, max_hops: int = 2) -> List[int]:\n",
+    "    \"\"\"Combine vector and graph retrieval.\"\"\"\n",
+    "    # Vector retrieval\n",
+    "    vector_docs = set(vector_retrieval(query, k=k_vector))\n",
+    "    \n",
+    "    # Graph retrieval\n",
+    "    query_entities = extract_query_entities(query)\n",
+    "    print(f\"  Query entities: {query_entities}\")\n",
+    "    graph_docs = graph_retrieval(query_entities, max_hops=max_hops)\n",
+    "    \n",
+    "    # Merge\n",
+    "    all_docs = vector_docs | graph_docs\n",
+    "    print(f\"  Vector: {sorted(vector_docs)} | Graph: {sorted(graph_docs)} | Merged: {sorted(all_docs)}\")\n",
+    "    \n",
+    "    return sorted(all_docs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 7: RAG vs GraphRAG \\u2014 Comparison\n",
+    "\n",
+    "We compare standard vector-only RAG with our hybrid GraphRAG on multi-hop questions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def answer_with_context(query: str, doc_indices: List[int], method_name: str) -> str:\n",
+    "    \"\"\"Generate an answer using retrieved documents as context.\"\"\"\n",
+    "    context = \"\\n\\n\".join([f\"[Doc {i}]: {documents[i]}\" for i in doc_indices])\n",
+    "    \n",
+    "    response = client.chat.complete(\n",
+    "        model=\"mistral-large-latest\",\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": \"Answer the question based only on the provided context. If the context doesn't contain enough information, say so.\"},\n",
+    "            {\"role\": \"user\", \"content\": f\"Context:\\n{context}\\n\\nQuestion: {query}\"}\n",
+    "        ]\n",
+    "    )\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "# Multi-hop questions that require connecting information across documents\n",
+    "test_questions = [\n",
+    "    \"What is the connection between Dr. Sarah Kim and QuantumCore's drug discovery partnership?\",\n",
+    "    \"Who are the academic collaborators behind QuantumCore, and what institutions are they from?\",\n",
+    "    \"Trace the funding and valuation history of QuantumCore, including who led the investment.\",\n",
+    "    \"How are NovaStar Pharma and Horizon Ventures connected through QuantumCore?\"\n",
+    "]\n",
+    "\n",
+    "print(\"=\" * 80)\n",
+    "print(\"RAG vs GraphRAG COMPARISON\")\n",
+    "print(\"=\" * 80)\n",
+    "\n",
+    "results = []\n",
+    "for q in test_questions:\n",
+    "    print(f\"\\n{'='*80}\")\n",
+    "    print(f\"QUESTION: {q}\")\n",
+    "    \n",
+    "    # Standard RAG (vector only)\n",
+    "    print(f\"\\n--- Standard RAG (top-3 vector) ---\")\n",
+    "    vector_docs = vector_retrieval(q, k=3)\n",
+    "    print(f\"  Retrieved docs: {vector_docs}\")\n",
+    "    rag_answer = answer_with_context(q, vector_docs, \"RAG\")\n",
+    "    print(f\"  Answer: {rag_answer[:200]}...\")\n",
+    "    \n",
+    "    # GraphRAG (hybrid)\n",
+    "    print(f\"\\n--- GraphRAG (hybrid) ---\")\n",
+    "    hybrid_docs = hybrid_retrieval(q, k_vector=3, max_hops=2)\n",
+    "    graphrag_answer = answer_with_context(q, hybrid_docs, \"GraphRAG\")\n",
+    "    print(f\"  Answer: {graphrag_answer[:200]}...\")\n",
+    "    \n",
+    "    results.append({\n",
+    "        \"question\": q,\n",
+    "        \"rag_docs\": len(vector_docs),\n",
+    "        \"graphrag_docs\": len(hybrid_docs),\n",
+    "        \"extra_docs\": len(set(hybrid_docs) - set(vector_docs))\n",
+    "    })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"\\n=== RETRIEVAL COMPARISON ===\\n\")\n",
+    "print(f\"{'Question':<70} {'RAG docs':>10} {'GraphRAG docs':>14} {'Extra from graph':>17}\")\n",
+    "print(\"-\" * 115)\n",
+    "for r in results:\n",
+    "    print(f\"{r['question'][:68]:<70} {r['rag_docs']:>10} {r['graphrag_docs']:>14} {r['extra_docs']:>17}\")\n",
+    "\n",
+    "avg_extra = sum(r['extra_docs'] for r in results) / len(results)\n",
+    "print(f\"\\nAverage extra documents from graph traversal: {avg_extra:.1f}\")\n",
+    "print(f\"Graph nodes: {G.number_of_nodes()} | Graph edges: {G.number_of_edges()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated a complete GraphRAG pipeline built from scratch with Mistral AI:\n",
+    "\n",
+    "| Component | Implementation |\n",
+    "|-----------|---------------|\n",
+    "| Entity extraction | Mistral Large + Pydantic structured outputs |\n",
+    "| Knowledge graph | NetworkX DiGraph with typed nodes and edges |\n",
+    "| Vector index | FAISS IndexFlatL2 with Mistral Embed (1024d) |\n",
+    "| Hybrid retrieval | Vector similarity + BFS graph traversal (2 hops) |\n",
+    "| Generation | Mistral Large with retrieved context |\n",
+    "\n",
+    "### Considerations:\n",
+    "- **Scaling**: For larger knowledge bases, consider Neo4j or ArangoDB instead of NetworkX\n",
+    "- **Entity resolution**: Add fuzzy matching or embedding-based deduplication for entity names\n",
+    "- **Graph updates**: Implement incremental extraction for new documents without rebuilding the full graph\n",
+    "- **Evaluation**: Compare retrieval metrics (precision@k, recall@k) between RAG and GraphRAG systematically\n",
+    "- **Production**: Add caching for embeddings and extraction results to reduce API costs"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Description

This notebook adds a complete **GraphRAG** pipeline built from scratch using only the Mistral AI SDK — no external graph databases required.

### What's included:
- **Entity & relationship extraction** using Mistral Large structured outputs (Pydantic models)
- **Knowledge graph construction** with NetworkX DiGraph
- **Visualization** of the entity relationship graph
- **Hybrid retrieval** combining FAISS vector search + BFS graph traversal
- **Side-by-side comparison** of standard RAG vs GraphRAG on multi-hop questions

### Stack:
`mistralai` + `networkx` + `faiss-cpu` + `pydantic` + `matplotlib`

### Why this matters:
The existing `camel_graph_rag.ipynb` requires CAMEL + Neo4j, making it hard to run on Colab. This notebook provides a lightweight, self-contained alternative that demonstrates GraphRAG concepts without external dependencies.

Tested locally with `mistral-large-latest` and `mistral-embed`.

## Checklist
- [x] Follows cookbook conventions (badge, getpass, structured sections)
- [x] All cells run sequentially
- [x] README updated
- [x] No API keys in code