### PR TITLE
feat(notebook): add LLMOps evaluation pipeline with MLflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [intent_classification.ipynb](mistral/classifier_factory/intent_classification.ipynb) | fine-tuning, classifier | Fine-tuning a classifier for intent classification. |
 | [moderation_classifier.ipynb](mistral/classifier_factory/moderation_classifier.ipynb) | fine-tuning, classifier | Fine-tuning a classifier for moderation. |
 | [pixtral_finetune_on_satellite_data.ipynb](mistral/fine_tune/pixtral_finetune_on_satellite_data.ipynb) | fine-tuning, image processing, batch | Fine-tuning a Pixtral-12B for satellite images classification. |
+| [llmops_evaluation_pipeline.ipynb](mistral/llmops/llmops_evaluation_pipeline.ipynb) | LLMOps, evaluation, MLflow | Complete LLMOps pipeline for model comparison and evaluation with MLflow |
 
 
 

--- a/mistral/llmops/llmops_evaluation_pipeline.ipynb
+++ b/mistral/llmops/llmops_evaluation_pipeline.ipynb
@@ -1,0 +1,477 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LLMOps: Model Evaluation & Comparison Pipeline with MLflow\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/mistralai/cookbook/blob/main/mistral/llmops/llmops_evaluation_pipeline.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "This notebook demonstrates a complete **LLMOps pipeline** for evaluating and comparing Mistral models using [MLflow](https://mlflow.org/). You'll learn how to:\n",
+    "\n",
+    "- Track experiments across different models and prompt variants\n",
+    "- Evaluate LLM outputs with custom and built-in metrics\n",
+    "- Compare mistral-small-latest vs mistral-large-latest on standardized tasks\n",
+    "- Version and manage prompts systematically\n",
+    "- Visualize results in an MLflow dashboard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install mistralai==1.5.0 mlflow==2.20.2 pandas==2.2.3 matplotlib==3.9.4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import time\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from getpass import getpass\n",
+    "from mistralai import Mistral\n",
+    "\n",
+    "import mlflow\n",
+    "\n",
+    "api_key = getpass(\"Type your Mistral API Key\")\n",
+    "client = Mistral(api_key=api_key)\n",
+    "\n",
+    "# Enable MLflow auto-tracing for Mistral\n",
+    "mlflow.mistral.autolog()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: MLflow Experiment Setup\n",
+    "\n",
+    "We create a dedicated experiment to track all our evaluation runs.\n",
+    "\n",
+    "### Considerations:\n",
+    "- MLflow stores all artifacts locally in Colab (or on a remote tracking server in production)\n",
+    "- Each \"run\" tracks parameters, metrics, and artifacts for reproducibility"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment_name = \"mistral-model-comparison\"\n",
+    "mlflow.set_experiment(experiment_name)\n",
+    "\n",
+    "print(f\"Experiment '{experiment_name}' created/loaded.\")\n",
+    "print(f\"Tracking URI: {mlflow.get_tracking_uri()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Evaluation Dataset\n",
+    "\n",
+    "We define a standardized evaluation dataset with ground truth answers for multiple task types."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_dataset = pd.DataFrame([\n",
+    "    {\n",
+    "        \"task\": \"summarization\",\n",
+    "        \"input\": \"The European Union announced new AI regulations requiring companies to disclose when content is AI-generated. The rules, part of the AI Act, will take effect in 2026 and include penalties up to 7% of global revenue for non-compliance. Tech companies have expressed mixed reactions, with some praising transparency while others warn about implementation challenges.\",\n",
+    "        \"expected_output\": \"The EU's AI Act mandates disclosure of AI-generated content, effective 2026, with fines up to 7% of revenue.\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"task\": \"extraction\",\n",
+    "        \"input\": \"Dr. Sarah Chen, a researcher at MIT, published a paper on quantum computing advances. The paper, titled 'Quantum Error Correction at Scale', was published in Nature on March 15, 2025.\",\n",
+    "        \"expected_output\": '{\"author\": \"Dr. Sarah Chen\", \"affiliation\": \"MIT\", \"title\": \"Quantum Error Correction at Scale\", \"journal\": \"Nature\", \"date\": \"March 15, 2025\"}'\n",
+    "    },\n",
+    "    {\n",
+    "        \"task\": \"reasoning\",\n",
+    "        \"input\": \"A train travels from City A to City B at 60 km/h and returns at 90 km/h. What is the average speed for the round trip?\",\n",
+    "        \"expected_output\": \"72 km/h\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"task\": \"code_generation\",\n",
+    "        \"input\": \"Write a Python function that checks if a string is a valid palindrome, ignoring spaces and punctuation.\",\n",
+    "        \"expected_output\": \"def is_palindrome(s):\\n    cleaned = ''.join(c.lower() for c in s if c.isalnum())\\n    return cleaned == cleaned[::-1]\"\n",
+    "    },\n",
+    "    {\n",
+    "        \"task\": \"classification\",\n",
+    "        \"input\": \"Review: 'The product arrived damaged and customer service was unhelpful. Very disappointed with the experience.'\",\n",
+    "        \"expected_output\": \"negative\"\n",
+    "    }\n",
+    "])\n",
+    "\n",
+    "print(f\"Evaluation dataset: {len(eval_dataset)} test cases\")\n",
+    "eval_dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Prompt Versioning\n",
+    "\n",
+    "We define multiple prompt strategies to compare their impact on model performance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt_versions = {\n",
+    "    \"v1_basic\": {\n",
+    "        \"system\": \"You are a helpful assistant.\",\n",
+    "        \"template\": \"{input}\"\n",
+    "    },\n",
+    "    \"v2_structured\": {\n",
+    "        \"system\": \"You are a precise AI assistant. Always provide concise, structured answers.\",\n",
+    "        \"template\": \"Task type: {task}\\n\\nInput: {input}\\n\\nProvide a concise response.\"\n",
+    "    },\n",
+    "    \"v3_cot\": {\n",
+    "        \"system\": \"You are an expert AI assistant. Think step by step before answering.\",\n",
+    "        \"template\": \"Task type: {task}\\n\\nInput: {input}\\n\\nThink step by step, then provide your final answer after 'ANSWER:'.\"\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Model Evaluation Loop\n",
+    "\n",
+    "We run each combination of (model, prompt_version) as a separate MLflow run, tracking all parameters and outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models_to_compare = [\"mistral-small-latest\", \"mistral-large-latest\"]\n",
+    "\n",
+    "def run_evaluation(model_name: str, prompt_version: str, prompt_config: dict) -> pd.DataFrame:\n",
+    "    \"\"\"Run a single evaluation: one model + one prompt version on the full dataset.\"\"\"\n",
+    "    results = []\n",
+    "    \n",
+    "    with mlflow.start_run(run_name=f\"{model_name}_{prompt_version}\"):\n",
+    "        # Log parameters\n",
+    "        mlflow.log_param(\"model\", model_name)\n",
+    "        mlflow.log_param(\"prompt_version\", prompt_version)\n",
+    "        mlflow.log_param(\"system_prompt\", prompt_config[\"system\"])\n",
+    "        mlflow.log_param(\"num_test_cases\", len(eval_dataset))\n",
+    "        \n",
+    "        for idx, row in eval_dataset.iterrows():\n",
+    "            user_message = prompt_config[\"template\"].format(\n",
+    "                task=row[\"task\"], input=row[\"input\"]\n",
+    "            )\n",
+    "            \n",
+    "            start_time = time.time()\n",
+    "            response = client.chat.complete(\n",
+    "                model=model_name,\n",
+    "                messages=[\n",
+    "                    {\"role\": \"system\", \"content\": prompt_config[\"system\"]},\n",
+    "                    {\"role\": \"user\", \"content\": user_message}\n",
+    "                ]\n",
+    "            )\n",
+    "            latency = time.time() - start_time\n",
+    "            \n",
+    "            output = response.choices[0].message.content\n",
+    "            tokens_used = response.usage.total_tokens\n",
+    "            \n",
+    "            results.append({\n",
+    "                \"task\": row[\"task\"],\n",
+    "                \"input\": row[\"input\"],\n",
+    "                \"expected\": row[\"expected_output\"],\n",
+    "                \"output\": output,\n",
+    "                \"latency_s\": round(latency, 3),\n",
+    "                \"tokens\": tokens_used,\n",
+    "                \"model\": model_name,\n",
+    "                \"prompt_version\": prompt_version\n",
+    "            })\n",
+    "        \n",
+    "        # Log aggregate metrics\n",
+    "        results_df = pd.DataFrame(results)\n",
+    "        mlflow.log_metric(\"avg_latency_s\", results_df[\"latency_s\"].mean())\n",
+    "        mlflow.log_metric(\"avg_tokens\", results_df[\"tokens\"].mean())\n",
+    "        mlflow.log_metric(\"total_tokens\", results_df[\"tokens\"].sum())\n",
+    "        \n",
+    "        # Log results as artifact\n",
+    "        mlflow.log_table(results_df, artifact_file=\"evaluation_results.json\")\n",
+    "    \n",
+    "    return results_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_results = []\n",
+    "\n",
+    "for model_name in models_to_compare:\n",
+    "    for prompt_version, prompt_config in prompt_versions.items():\n",
+    "        print(f\"\\nEvaluating: {model_name} with {prompt_version}...\")\n",
+    "        result_df = run_evaluation(model_name, prompt_version, prompt_config)\n",
+    "        all_results.append(result_df)\n",
+    "        print(f\"  Avg latency: {result_df['latency_s'].mean():.3f}s | Avg tokens: {result_df['tokens'].mean():.0f}\")\n",
+    "\n",
+    "combined_results = pd.concat(all_results, ignore_index=True)\n",
+    "print(f\"\\nTotal evaluations: {len(combined_results)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: LLM-as-Judge Evaluation\n",
+    "\n",
+    "We use Mistral Large to judge the quality of each output compared to the expected output.\n",
+    "\n",
+    "### Considerations:\n",
+    "- Using a separate LLM call as judge provides more nuanced evaluation than string matching\n",
+    "- We use a simple 1-5 scoring system for consistency"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def judge_output(task: str, input_text: str, expected: str, actual: str) -> dict:\n",
+    "    \"\"\"Use Mistral Large as a judge to score output quality.\"\"\"\n",
+    "    prompt = f\"\"\"You are an expert evaluator. Score the following AI output on a scale of 1-5.\n",
+    "\n",
+    "Task type: {task}\n",
+    "Input: {input_text}\n",
+    "Expected output: {expected}\n",
+    "Actual output: {actual}\n",
+    "\n",
+    "Score criteria:\n",
+    "5 = Perfect match or better than expected\n",
+    "4 = Very good, minor differences\n",
+    "3 = Acceptable, captures main points\n",
+    "2 = Partial, misses key elements\n",
+    "1 = Poor, incorrect or irrelevant\n",
+    "\n",
+    "Return ONLY a JSON object with \"score\" (integer 1-5) and \"reasoning\" (string).\"\"\"\n",
+    "\n",
+    "    response = client.chat.complete(\n",
+    "        model=\"mistral-large-latest\",\n",
+    "        messages=[{\"role\": \"user\", \"content\": prompt}],\n",
+    "        response_format={\"type\": \"json_object\"}\n",
+    "    )\n",
+    "    \n",
+    "    return json.loads(response.choices[0].message.content)\n",
+    "\n",
+    "# Run LLM-as-Judge on all results\n",
+    "judge_scores = []\n",
+    "for idx, row in combined_results.iterrows():\n",
+    "    score_data = judge_output(row[\"task\"], row[\"input\"], row[\"expected\"], row[\"output\"])\n",
+    "    judge_scores.append(score_data.get(\"score\", 0))\n",
+    "    if idx % 10 == 0:\n",
+    "        print(f\"Judging... {idx+1}/{len(combined_results)}\")\n",
+    "\n",
+    "combined_results[\"judge_score\"] = judge_scores\n",
+    "print(f\"\\nJudging complete. Average score: {combined_results['judge_score'].mean():.2f}/5\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Log Judge Scores to MLflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Log judge scores as a separate MLflow run for each model+prompt combo\n",
+    "for model_name in models_to_compare:\n",
+    "    for prompt_version in prompt_versions.keys():\n",
+    "        subset = combined_results[\n",
+    "            (combined_results[\"model\"] == model_name) & \n",
+    "            (combined_results[\"prompt_version\"] == prompt_version)\n",
+    "        ]\n",
+    "        \n",
+    "        with mlflow.start_run(run_name=f\"judge_{model_name}_{prompt_version}\"):\n",
+    "            mlflow.log_param(\"model\", model_name)\n",
+    "            mlflow.log_param(\"prompt_version\", prompt_version)\n",
+    "            mlflow.log_param(\"evaluation_type\", \"llm_as_judge\")\n",
+    "            mlflow.log_metric(\"avg_judge_score\", subset[\"judge_score\"].mean())\n",
+    "            mlflow.log_metric(\"min_judge_score\", subset[\"judge_score\"].min())\n",
+    "            mlflow.log_metric(\"max_judge_score\", subset[\"judge_score\"].max())\n",
+    "\n",
+    "print(\"Judge scores logged to MLflow.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 7: Results Visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(18, 5))\n",
+    "\n",
+    "# 1. Judge scores by model and prompt\n",
+    "score_pivot = combined_results.pivot_table(\n",
+    "    values=\"judge_score\", index=\"task\", columns=[\"model\", \"prompt_version\"], aggfunc=\"mean\"\n",
+    ")\n",
+    "score_pivot.plot(kind=\"bar\", ax=axes[0], rot=45)\n",
+    "axes[0].set_title(\"Judge Score by Task, Model & Prompt\")\n",
+    "axes[0].set_ylabel(\"Score (1-5)\")\n",
+    "axes[0].legend(fontsize=6)\n",
+    "axes[0].set_ylim(0, 5.5)\n",
+    "\n",
+    "# 2. Latency comparison\n",
+    "latency_pivot = combined_results.pivot_table(\n",
+    "    values=\"latency_s\", index=\"model\", columns=\"prompt_version\", aggfunc=\"mean\"\n",
+    ")\n",
+    "latency_pivot.plot(kind=\"bar\", ax=axes[1], rot=0)\n",
+    "axes[1].set_title(\"Average Latency by Model & Prompt\")\n",
+    "axes[1].set_ylabel(\"Latency (seconds)\")\n",
+    "\n",
+    "# 3. Cost estimation\n",
+    "cost_map = {\"mistral-small-latest\": 0.0000001, \"mistral-large-latest\": 0.000002}\n",
+    "combined_results[\"estimated_cost\"] = combined_results.apply(\n",
+    "    lambda r: r[\"tokens\"] * cost_map.get(r[\"model\"], 0), axis=1\n",
+    ")\n",
+    "cost_pivot = combined_results.pivot_table(\n",
+    "    values=\"estimated_cost\", index=\"task\", columns=\"model\", aggfunc=\"sum\"\n",
+    ")\n",
+    "cost_pivot.plot(kind=\"bar\", ax=axes[2], rot=45)\n",
+    "axes[2].set_title(\"Estimated Cost by Task & Model\")\n",
+    "axes[2].set_ylabel(\"Cost ($)\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 8: Summary Report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary = combined_results.groupby([\"model\", \"prompt_version\"]).agg({\n",
+    "    \"judge_score\": \"mean\",\n",
+    "    \"latency_s\": \"mean\",\n",
+    "    \"tokens\": [\"mean\", \"sum\"],\n",
+    "    \"estimated_cost\": \"sum\"\n",
+    "}).round(4)\n",
+    "\n",
+    "print(\"=== EVALUATION SUMMARY ===\\n\")\n",
+    "print(summary.to_string())\n",
+    "\n",
+    "# Best configuration\n",
+    "best_idx = combined_results.groupby([\"model\", \"prompt_version\"])[\"judge_score\"].mean().idxmax()\n",
+    "print(f\"\\nBest configuration: {best_idx[0]} with {best_idx[1]} (avg score: {combined_results.groupby(['model', 'prompt_version'])['judge_score'].mean().max():.2f}/5)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 9: MLflow Dashboard\n",
+    "\n",
+    "To view the full MLflow dashboard with all runs, metrics, and artifacts:\n",
+    "\n",
+    "```bash\n",
+    "mlflow ui --port 5000\n",
+    "```\n",
+    "\n",
+    "Then open http://localhost:5000 in your browser."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook implemented a full LLMOps evaluation pipeline:\n",
+    "\n",
+    "| Step | Tool | Purpose |\n",
+    "|------|------|---------|\n",
+    "| Experiment tracking | `mlflow.set_experiment()` | Organize evaluation runs |\n",
+    "| Auto-tracing | `mlflow.mistral.autolog()` | Automatic trace capture |\n",
+    "| Parameterization | `mlflow.log_param()` | Track model/prompt versions |\n",
+    "| LLM-as-Judge | Mistral Large | Score outputs 1-5 with reasoning |\n",
+    "| Visualization | matplotlib + MLflow UI | Compare results |\n",
+    "\n",
+    "### Considerations:\n",
+    "- **Production deployment**: Replace local MLflow with a remote tracking server (e.g., Databricks, self-hosted)\n",
+    "- **CI/CD integration**: Wrap this pipeline in a script for automated evaluation on model updates\n",
+    "- **Custom metrics**: Define domain-specific evaluation metrics beyond the 1-5 judge score\n",
+    "- **Prompt registry**: Use MLflow's Model Registry to version and stage prompts alongside models\n",
+    "- **A/B testing**: Use this framework to compare model versions before production rollout"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

This notebook demonstrates a **complete LLMOps pipeline** for evaluating and comparing Mistral models:

- **MLflow integration**: Experiment tracking, parameter logging, auto-tracing via `mlflow.mistral.autolog()`
- **Model comparison**: mistral-small-latest vs mistral-large-latest across 5 task types
- **Prompt versioning**: 3 strategies (basic, structured, chain-of-thought) tracked as parameters
- **LLM-as-Judge**: Mistral Large scores each output 1-5 with reasoning
- **Cost analysis**: Token usage and estimated cost comparison
- **Visualization**: matplotlib charts for scores, latency, and cost

### New directory
This creates the `mistral/llmops/` directory — the first LLMOps notebook in the cookbook.

### Stack
- `mistralai` — Model inference and evaluation
- `mlflow` — Experiment tracking, auto-tracing, artifact logging
- `pandas` — Data manipulation
- `matplotlib` — Visualization

### Notebook structure
1. MLflow experiment setup with auto-tracing
2. Standardized evaluation dataset (5 tasks)
3. 3 prompt versions (basic → structured → chain-of-thought)
4. Evaluation loop: 2 models × 3 prompts = 6 MLflow runs
5. LLM-as-Judge scoring with Mistral Large
6. Results visualization and summary report