### PR TITLE
feat(notebook): add LangGraph multi-agent orchestration with Mistral

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [Indexify Integration - PDF Entity Extraction](third_party/Indexify/pdf-entity-extraction)                            | entity extraction, PDF          | Indexify   |
 | [Indexify Integration - PDF Summarization](third_party/Indexify/pdf-summarization)                                    | summarization, PDF              | Indexify   |
 | [langgraph_code_assistant_mistral.ipynb](third_party/langchain/langgraph_code_assistant_mistral.ipynb)                | code                            | Langchain  |
+| [langgraph_multi_agent_orchestration.ipynb](third_party/langchain/langgraph_multi_agent_orchestration.ipynb)          | multi-agent, orchestration      | Langchain  |
 | [langgraph_crag_mistral.ipynb](third_party/langchain/langgraph_crag_mistral.ipynb)                                    | RAG                             | Langchain  |
 | [langtrace_mistral.ipynb](third_party/langtrace/langtrace_mistral.ipynb)                                              | OTEL Observability              | Langtrace  |
 | [llamaindex_agentic_rag.ipynb](third_party/LlamaIndex/llamaindex_agentic_rag.ipynb)                                   | RAG, agent                      | LLamaIndex |

--- a/third_party/langchain/langgraph_multi_agent_orchestration.ipynb
+++ b/third_party/langchain/langgraph_multi_agent_orchestration.ipynb
@@ -1,0 +1,481 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multi-Agent Orchestration with LangGraph and Mistral AI\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/mistralai/cookbook/blob/main/third_party/langchain/langgraph_multi_agent_orchestration.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "This notebook demonstrates how to build a **multi-agent orchestration system** using [LangGraph](https://langchain-ai.github.io/langgraph/) with Mistral AI. The system features:\n",
+    "\n",
+    "- A **Router** agent that classifies incoming queries and routes them to specialists\n",
+    "- Three **specialist agents** (Researcher, Coder, Reviewer) with distinct capabilities\n",
+    "- An **Evaluator** that scores response quality using LLM-as-Judge\n",
+    "- **Automatic retry logic** when quality is below threshold\n",
+    "\n",
+    "**Key concepts:**\n",
+    "- `StateGraph` with shared `TypedDict` state\n",
+    "- Conditional routing with `add_conditional_edges`\n",
+    "- Structured outputs with Pydantic models via `with_structured_output()`\n",
+    "- Quality-based retry loop with max retries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture --no-stderr\n",
+    "%pip install --quiet -U langchain-mistralai==1.1.1 langgraph==1.0.10 tavily-python==0.5.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import getpass\n",
+    "\n",
+    "def _set_env(var: str):\n",
+    "    if not os.environ.get(var):\n",
+    "        os.environ[var] = getpass.getpass(f\"{var}: \")\n",
+    "\n",
+    "_set_env(\"MISTRAL_API_KEY\")\n",
+    "_set_env(\"TAVILY_API_KEY\")  # Free tier: https://tavily.com (1000 requests/month)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize the LLM and Tools\n",
+    "\n",
+    "We use `ChatMistralAI` with `mistral-large-latest` for all agents, and Tavily for web search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_mistralai import ChatMistralAI\n",
+    "from langchain_community.tools.tavily_search import TavilySearchResults\n",
+    "\n",
+    "llm = ChatMistralAI(model=\"mistral-large-latest\", temperature=0)\n",
+    "web_search_tool = TavilySearchResults(max_results=3)\n",
+    "\n",
+    "print(f\"LLM: {llm.model}\")\n",
+    "print(f\"Search tool: {web_search_tool.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Structured Output Models\n",
+    "\n",
+    "We use Pydantic models with `llm.with_structured_output()` for deterministic routing and quality grading."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pydantic import BaseModel, Field\n",
+    "from typing import Literal\n",
+    "\n",
+    "class RouteQuery(BaseModel):\n",
+    "    \"\"\"Route a user query to the most appropriate specialist agent.\"\"\"\n",
+    "    agent: Literal[\"researcher\", \"coder\", \"reviewer\"] = Field(\n",
+    "        description=\"The specialist agent to handle this query: \"\n",
+    "        \"'researcher' for information gathering and analysis, \"\n",
+    "        \"'coder' for code generation and debugging, \"\n",
+    "        \"'reviewer' for evaluating and improving content\"\n",
+    "    )\n",
+    "    reasoning: str = Field(description=\"Brief explanation of why this agent was selected\")\n",
+    "\n",
+    "class QualityGrade(BaseModel):\n",
+    "    \"\"\"Grade the quality of an agent's response.\"\"\"\n",
+    "    score: Literal[\"pass\", \"fail\"] = Field(\n",
+    "        description=\"'pass' if the response adequately addresses the query, 'fail' if it needs improvement\"\n",
+    "    )\n",
+    "    feedback: str = Field(description=\"Specific feedback on what could be improved\")\n",
+    "\n",
+    "structured_llm_router = llm.with_structured_output(RouteQuery)\n",
+    "structured_llm_quality = llm.with_structured_output(QualityGrade)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the Graph State\n",
+    "\n",
+    "The shared state is a `TypedDict` that all agents can read and modify."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import TypedDict, List\n",
+    "\n",
+    "class GraphState(TypedDict):\n",
+    "    \"\"\"State shared across all agents in the multi-agent system.\"\"\"\n",
+    "    question: str\n",
+    "    task_type: str\n",
+    "    generation: str\n",
+    "    documents: List[str]\n",
+    "    quality_score: str\n",
+    "    quality_feedback: str\n",
+    "    retry_count: int\n",
+    "    max_retries: int\n",
+    "    routing_reasoning: str"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Node Functions\n",
+    "\n",
+    "Each node is a function that reads and modifies the shared state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import HumanMessage, SystemMessage\n",
+    "\n",
+    "def route_query(state):\n",
+    "    \"\"\"Route the query to the appropriate specialist agent.\"\"\"\n",
+    "    print(\"---ROUTING QUERY---\")\n",
+    "    question = state[\"question\"]\n",
+    "    \n",
+    "    result = structured_llm_router.invoke([\n",
+    "        SystemMessage(content=\"\"\"You are a task router. Analyze the user's query and route it to the best agent:\n",
+    "- researcher: For questions requiring web search, information gathering, analysis, or explanation\n",
+    "- coder: For code generation, debugging, algorithm implementation, or technical programming tasks\n",
+    "- reviewer: For reviewing, critiquing, or improving existing text, code, or documents\"\"\"),\n",
+    "        HumanMessage(content=question)\n",
+    "    ])\n",
+    "    \n",
+    "    print(f\"  Routed to: {result.agent} (Reason: {result.reasoning})\")\n",
+    "    return {\"task_type\": result.agent, \"routing_reasoning\": result.reasoning}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def researcher_agent(state):\n",
+    "    \"\"\"Research agent: gathers information via web search and synthesizes an answer.\"\"\"\n",
+    "    print(\"---RESEARCHER AGENT---\")\n",
+    "    question = state[\"question\"]\n",
+    "    feedback = state.get(\"quality_feedback\", \"\")\n",
+    "    \n",
+    "    # Web search\n",
+    "    search_results = web_search_tool.invoke({\"query\": question})\n",
+    "    documents = [d[\"content\"] for d in search_results] if isinstance(search_results, list) else [str(search_results)]\n",
+    "    \n",
+    "    context = \"\\n\\n\".join(documents)\n",
+    "    \n",
+    "    enhanced_prompt = question\n",
+    "    if feedback:\n",
+    "        enhanced_prompt += f\"\\n\\nPrevious attempt feedback: {feedback}. Please address these points.\"\n",
+    "    \n",
+    "    response = llm.invoke([\n",
+    "        SystemMessage(content=f\"\"\"You are a research specialist. Provide a thorough, well-sourced answer based on the following search results.\n",
+    "\n",
+    "Search Results:\n",
+    "{context}\n",
+    "\n",
+    "Structure your response with clear sections and cite specific findings.\"\"\"),\n",
+    "        HumanMessage(content=enhanced_prompt)\n",
+    "    ])\n",
+    "    \n",
+    "    return {\"generation\": response.content, \"documents\": documents}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def coder_agent(state):\n",
+    "    \"\"\"Coder agent: generates, debugs, or explains code.\"\"\"\n",
+    "    print(\"---CODER AGENT---\")\n",
+    "    question = state[\"question\"]\n",
+    "    feedback = state.get(\"quality_feedback\", \"\")\n",
+    "    \n",
+    "    enhanced_prompt = question\n",
+    "    if feedback:\n",
+    "        enhanced_prompt += f\"\\n\\nPrevious attempt feedback: {feedback}. Please fix the issues.\"\n",
+    "    \n",
+    "    response = llm.invoke([\n",
+    "        SystemMessage(content=\"\"\"You are an expert programmer. When asked to write code:\n",
+    "1. Provide clean, well-documented code\n",
+    "2. Include type hints and docstrings\n",
+    "3. Add usage examples\n",
+    "4. Explain key design decisions\n",
+    "When debugging, identify the root cause and provide a fix.\"\"\"),\n",
+    "        HumanMessage(content=enhanced_prompt)\n",
+    "    ])\n",
+    "    \n",
+    "    return {\"generation\": response.content}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def reviewer_agent(state):\n",
+    "    \"\"\"Reviewer agent: evaluates and improves content quality.\"\"\"\n",
+    "    print(\"---REVIEWER AGENT---\")\n",
+    "    question = state[\"question\"]\n",
+    "    feedback = state.get(\"quality_feedback\", \"\")\n",
+    "    \n",
+    "    enhanced_prompt = question\n",
+    "    if feedback:\n",
+    "        enhanced_prompt += f\"\\n\\nPrevious review feedback: {feedback}. Please provide a more thorough review.\"\n",
+    "    \n",
+    "    response = llm.invoke([\n",
+    "        SystemMessage(content=\"\"\"You are an expert reviewer. Provide constructive, detailed feedback with:\n",
+    "1. Strengths of the content\n",
+    "2. Areas for improvement (be specific)\n",
+    "3. Suggested corrections or rewrites\n",
+    "4. An overall quality assessment\"\"\"),\n",
+    "        HumanMessage(content=enhanced_prompt)\n",
+    "    ])\n",
+    "    \n",
+    "    return {\"generation\": response.content}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate_quality(state):\n",
+    "    \"\"\"Evaluate the quality of the agent's response.\"\"\"\n",
+    "    print(\"---EVALUATING QUALITY---\")\n",
+    "    question = state[\"question\"]\n",
+    "    generation = state[\"generation\"]\n",
+    "    \n",
+    "    result = structured_llm_quality.invoke([\n",
+    "        SystemMessage(content=\"Evaluate whether this response adequately addresses the user's question. \"\n",
+    "                     \"Consider completeness, accuracy, and helpfulness.\"),\n",
+    "        HumanMessage(content=f\"Question: {question}\\n\\nResponse: {generation}\")\n",
+    "    ])\n",
+    "    \n",
+    "    print(f\"  Quality: {result.score} | Feedback: {result.feedback}\")\n",
+    "    retry_count = state.get(\"retry_count\", 0) + 1\n",
+    "    \n",
+    "    return {\n",
+    "        \"quality_score\": result.score,\n",
+    "        \"quality_feedback\": result.feedback,\n",
+    "        \"retry_count\": retry_count\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build the Multi-Agent Graph\n",
+    "\n",
+    "We wire together the routing, agent execution, quality evaluation, and retry logic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.graph import StateGraph, END\n",
+    "from IPython.display import Image, display\n",
+    "\n",
+    "def route_to_agent(state):\n",
+    "    \"\"\"Route to the selected agent based on task_type.\"\"\"\n",
+    "    return state[\"task_type\"]\n",
+    "\n",
+    "def should_retry(state):\n",
+    "    \"\"\"Decide whether to retry or finish based on quality evaluation.\"\"\"\n",
+    "    if state[\"quality_score\"] == \"pass\":\n",
+    "        return \"end\"\n",
+    "    if state.get(\"retry_count\", 0) >= state.get(\"max_retries\", 2):\n",
+    "        print(\"  Max retries reached. Returning best effort response.\")\n",
+    "        return \"end\"\n",
+    "    return state[\"task_type\"]\n",
+    "\n",
+    "workflow = StateGraph(GraphState)\n",
+    "\n",
+    "# Add nodes\n",
+    "workflow.add_node(\"router\", route_query)\n",
+    "workflow.add_node(\"researcher\", researcher_agent)\n",
+    "workflow.add_node(\"coder\", coder_agent)\n",
+    "workflow.add_node(\"reviewer\", reviewer_agent)\n",
+    "workflow.add_node(\"evaluator\", evaluate_quality)\n",
+    "\n",
+    "# Build graph\n",
+    "workflow.set_entry_point(\"router\")\n",
+    "\n",
+    "workflow.add_conditional_edges(\"router\", route_to_agent, {\n",
+    "    \"researcher\": \"researcher\",\n",
+    "    \"coder\": \"coder\",\n",
+    "    \"reviewer\": \"reviewer\"\n",
+    "})\n",
+    "\n",
+    "# All agents feed into the evaluator\n",
+    "workflow.add_edge(\"researcher\", \"evaluator\")\n",
+    "workflow.add_edge(\"coder\", \"evaluator\")\n",
+    "workflow.add_edge(\"reviewer\", \"evaluator\")\n",
+    "\n",
+    "# Evaluator decides: pass -> end, fail -> retry agent\n",
+    "workflow.add_conditional_edges(\"evaluator\", should_retry, {\n",
+    "    \"end\": END,\n",
+    "    \"researcher\": \"researcher\",\n",
+    "    \"coder\": \"coder\",\n",
+    "    \"reviewer\": \"reviewer\"\n",
+    "})\n",
+    "\n",
+    "graph = workflow.compile()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    display(Image(graph.get_graph().draw_mermaid_png()))\n",
+    "except Exception:\n",
+    "    print(graph.get_graph().draw_mermaid())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing the Multi-Agent System"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = graph.invoke({\n",
+    "    \"question\": \"What are the latest advances in agentic AI systems in 2024-2025?\",\n",
+    "    \"max_retries\": 2, \"retry_count\": 0\n",
+    "})\n",
+    "print(\"\\n=== FINAL ANSWER ===\")\n",
+    "print(result[\"generation\"][:500])\n",
+    "print(f\"\\nRouting: {result['routing_reasoning']}\")\n",
+    "print(f\"Quality: {result['quality_score']} (retries: {result['retry_count']})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = graph.invoke({\n",
+    "    \"question\": \"Write a Python async web scraper with rate limiting and retry logic using aiohttp\",\n",
+    "    \"max_retries\": 2, \"retry_count\": 0\n",
+    "})\n",
+    "print(\"\\n=== FINAL ANSWER ===\")\n",
+    "print(result[\"generation\"][:500])\n",
+    "print(f\"\\nQuality: {result['quality_score']} (retries: {result['retry_count']})\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = graph.invoke({\n",
+    "    \"question\": \"Review this code for security issues: `user_input = input('Enter expression: '); result = eval(user_input)`\",\n",
+    "    \"max_retries\": 2, \"retry_count\": 0\n",
+    "})\n",
+    "print(\"\\n=== FINAL ANSWER ===\")\n",
+    "print(result[\"generation\"][:500])\n",
+    "print(f\"\\nQuality: {result['quality_score']} (retries: {result['retry_count']})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated a complete multi-agent orchestration system with:\n",
+    "\n",
+    "| Component | Implementation |\n",
+    "|-----------|---------------|\n",
+    "| Router | Pydantic structured output for agent selection |\n",
+    "| Agents | 3 specialists (Researcher, Coder, Reviewer) |\n",
+    "| State | Shared GraphState with full conversation history |\n",
+    "| Quality | LLM-as-judge evaluation with automatic retry |\n",
+    "| Error handling | Max retry limit prevents infinite loops |\n",
+    "\n",
+    "### Considerations:\n",
+    "- **Scaling agents**: Add new agents by defining a node function and adding routing logic\n",
+    "- **Persistence**: Add LangGraph checkpointing for conversation memory across sessions\n",
+    "- **Parallel execution**: LangGraph supports parallel node execution for independent agents\n",
+    "- **Cost optimization**: Use `mistral-small-latest` for routing, `mistral-large-latest` for generation"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

This notebook demonstrates a **multi-agent orchestration system** using LangGraph with Mistral AI:

- **Router agent**: Uses Pydantic structured outputs to classify and route queries
- **3 specialist agents**: Researcher (with Tavily web search), Coder, Reviewer
- **Quality evaluator**: LLM-as-Judge with automatic retry on failure
- **StateGraph**: Shared TypedDict state with conditional routing edges

### Architecture
```
User Query → Router → {Researcher|Coder|Reviewer} → Evaluator → Pass? → Output
                                                         ↓ Fail
                                                    Retry (max 2)
```

### Stack
- `langchain-mistralai` — ChatMistralAI with structured outputs
- `langgraph` — StateGraph, conditional edges, compilation
- `tavily-python` — Web search for the Researcher agent
- `pydantic` — RouteQuery, QualityGrade models

### Key features
- Deterministic routing via `with_structured_output()`
- Quality-based retry loop with configurable max retries
- Feedback propagation: evaluator feedback is passed back to agents on retry
- Graph visualization via Mermaid