### PR TITLE
Add AG2 multi-agent example with Mistral models

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 |:----------------------------------------------------------------------------------------------------------------------|:--------------------------------| :--------- |
 | [adaptive_rag_mistral.ipynb](third_party/langchain/adaptive_rag_mistral.ipynb)                                        | RAG                             | Langchain  |
 | [Adaptive_RAG.ipynb](third_party/LlamaIndex/Adaptive_RAG.ipynb)                                                       | RAG                             | LLamaIndex |
+| [Multi-Agent Orchestration with AG2](third_party/AG2/ag2_multi_agent_mistral.ipynb)                                   | Agents, Function calling        | AG2        |
 | [Agents_Tools.ipynb](third_party/LlamaIndex/Agents_Tools.ipynb)                                                       | agent                           | LLamaIndex |
 | [arize_phoenix_tracing.ipynb](third_party/Phoenix/arize_phoenix_tracing.ipynb)                                        | tracing data                    | Arize Phoenix  |
 | [arize_phoenix_evaluate_rag.ipynb](third_party/Phoenix/arize_phoenix_evaluate_rag.ipynb)                              | evaluation                      | Arize Phoenix  |

--- a/third_party/AG2/ag2_multi_agent_mistral.ipynb
+++ b/third_party/AG2/ag2_multi_agent_mistral.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Multi-Agent Orchestration with AG2 and Mistral\n\n[AG2](https://ag2.ai/) (formerly AutoGen) is an open-source multi-agent framework\nwith 400K+ monthly PyPI downloads. This notebook demonstrates how to build\nmulti-agent systems using AG2 with Mistral models.\n\nWe'll cover three patterns:\n1. **Basic conversation** — two-agent chat with Mistral\n2. **Function calling** — tool registration and execution\n3. **GroupChat** — multi-agent orchestration with automatic speaker selection\n\n*Author: [Faridun Mirzoev](https://github.com/faridun-ag2) — AG2 Team*"
+   "source": "# Multi-Agent Orchestration with AG2 and Mistral\n\n[AG2](https://ag2.ai/) (formerly AutoGen) is an open-source multi-agent framework\nwith 500K+ monthly PyPI downloads. This notebook demonstrates how to build\nmulti-agent systems using AG2 with Mistral models.\n\nWe'll cover three patterns:\n1. **Basic conversation** — two-agent chat with Mistral\n2. **Function calling** — tool registration and execution\n3. **GroupChat** — multi-agent orchestration with automatic speaker selection\n\n*Author: [Faridun Mirzoev](https://github.com/faridun-ag2) — AG2 Team*"
   },
   {
    "cell_type": "code",

--- a/third_party/AG2/ag2_multi_agent_mistral.ipynb
+++ b/third_party/AG2/ag2_multi_agent_mistral.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Multi-Agent Orchestration with AG2 and Mistral\n\n[AG2](https://ag2.ai/) (formerly AutoGen) is an open-source multi-agent framework\nwith 400K+ monthly PyPI downloads. This notebook demonstrates how to build\nmulti-agent systems using AG2 with Mistral models.\n\nWe'll cover three patterns:\n1. **Basic conversation** — two-agent chat with Mistral\n2. **Function calling** — tool registration and execution\n3. **GroupChat** — multi-agent orchestration with automatic speaker selection\n\n*Author: [Faridun Mirzoev](https://github.com/faridun-ag2) — AG2 Team*"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "!pip install -q ag2[openai]==0.11.4 mistralai==2.1.3 python-dotenv==1.0.1"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "# Verify API key is set\n",
+    "assert os.getenv(\"MISTRAL_API_KEY\"), \"Set MISTRAL_API_KEY environment variable\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Basic Two-Agent Conversation\n\nAG2's fundamental pattern: an `AssistantAgent` (LLM-powered) talks to a\n`UserProxyAgent` (represents the user, can execute tools).\n\nAG2 supports Mistral natively via `MistralLLMConfigEntry` — no wrapper needed."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from autogen import AssistantAgent, UserProxyAgent, LLMConfig\nfrom autogen.oai.mistral import MistralLLMConfigEntry\n\n# AG2 native Mistral support\nllm_config = LLMConfig(\n    MistralLLMConfigEntry(\n        model=\"mistral-large-latest\",\n        api_key=os.getenv(\"MISTRAL_API_KEY\"),\n    )\n)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "assistant = AssistantAgent(\n    name=\"Assistant\",\n    system_message=(\n        \"You are a helpful AI assistant powered by Mistral. \"\n        \"Provide clear, concise answers.\"\n    ),\n    llm_config=llm_config,\n)\n\nuser_proxy = UserProxyAgent(\n    name=\"User\",\n    human_input_mode=\"NEVER\",\n    max_consecutive_auto_reply=1,\n    code_execution_config=False,\n)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "result = user_proxy.run(\n    assistant,\n    message=\"What makes Mistral models unique compared to other LLM providers?\",\n)\nresult.process()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Function Calling with Mistral\n",
+    "\n",
+    "AG2 uses a dual registration pattern for tools:\n",
+    "- `register_for_llm()` — tells Mistral the tool exists (generates the JSON schema)\n",
+    "- `register_for_execution()` — tells the UserProxy how to execute it\n",
+    "\n",
+    "Mistral Large supports function calling natively, and AG2 handles the schema\n",
+    "generation automatically from Python type hints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Annotated\n",
+    "\n",
+    "\n",
+    "def get_weather(\n",
+    "    city: Annotated[str, \"City name to get weather for\"],\n",
+    ") -> str:\n",
+    "    \"\"\"Get the current weather for a city.\"\"\"\n",
+    "    # Simulated weather data for demo\n",
+    "    weather_data = {\n",
+    "        \"paris\": \"Paris: 18\\u00b0C, partly cloudy, humidity 65%\",\n",
+    "        \"london\": \"London: 14\\u00b0C, rainy, humidity 80%\",\n",
+    "        \"tokyo\": \"Tokyo: 22\\u00b0C, sunny, humidity 55%\",\n",
+    "        \"new york\": \"New York: 20\\u00b0C, clear skies, humidity 50%\",\n",
+    "        \"san francisco\": \"San Francisco: 16\\u00b0C, foggy, humidity 75%\",\n",
+    "    }\n",
+    "    return weather_data.get(city.lower(), f\"Weather data not available for {city}\")\n",
+    "\n",
+    "\n",
+    "def get_local_time(\n",
+    "    city: Annotated[str, \"City name to get local time for\"],\n",
+    ") -> str:\n",
+    "    \"\"\"Get the current local time for a city.\"\"\"\n",
+    "    # Simulated time data for demo\n",
+    "    times = {\n",
+    "        \"paris\": \"14:30 CET (UTC+1)\",\n",
+    "        \"london\": \"13:30 GMT (UTC+0)\",\n",
+    "        \"tokyo\": \"22:30 JST (UTC+9)\",\n",
+    "        \"new york\": \"08:30 EST (UTC-5)\",\n",
+    "        \"san francisco\": \"05:30 PST (UTC-8)\",\n",
+    "    }\n",
+    "    return times.get(city.lower(), f\"Time data not available for {city}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "travel_agent = AssistantAgent(\n    name=\"TravelAgent\",\n    system_message=(\n        \"You are a travel assistant. Use the available tools to help \"\n        \"users plan their trips. Always check weather and local time.\"\n    ),\n    llm_config=llm_config,\n)\n\nuser_proxy = UserProxyAgent(\n    name=\"User\",\n    human_input_mode=\"NEVER\",\n    max_consecutive_auto_reply=5,\n    code_execution_config=False,\n)\n\n# Register tools — AG2 dual pattern\ntravel_agent.register_for_llm(description=\"Get current weather\")(get_weather)\ntravel_agent.register_for_llm(description=\"Get local time\")(get_local_time)\nuser_proxy.register_for_execution()(get_weather)\nuser_proxy.register_for_execution()(get_local_time)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "result = user_proxy.run(\n    travel_agent,\n    message=\"I'm planning a trip to Paris and Tokyo next week. \"\n            \"What's the weather like and what time is it there now?\",\n)\nresult.process()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Multi-Agent GroupChat\n",
+    "\n",
+    "AG2's flagship feature: **GroupChat** with automatic speaker selection.\n",
+    "Define specialist agents, and the `GroupChatManager` uses Mistral to decide\n",
+    "which agent should respond next — no routing code needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from autogen import GroupChat, GroupChatManager\n\nresearcher = AssistantAgent(\n    name=\"Researcher\",\n    system_message=(\n        \"You are a research analyst. Gather facts and provide \"\n        \"well-sourced analysis on the topic at hand.\"\n    ),\n    llm_config=llm_config,\n)\nwriter = AssistantAgent(\n    name=\"Writer\",\n    system_message=(\n        \"You are a skilled writer. Create clear, engaging content \"\n        \"from research findings. Focus on readability.\"\n    ),\n    llm_config=llm_config,\n)\ncritic = AssistantAgent(\n    name=\"Critic\",\n    system_message=(\n        \"You review content for accuracy, clarity, and completeness. \"\n        \"Provide constructive feedback. Say TERMINATE when satisfied.\"\n    ),\n    llm_config=llm_config,\n)\nuser_proxy = UserProxyAgent(\n    name=\"User\",\n    human_input_mode=\"NEVER\",\n    max_consecutive_auto_reply=0,\n    code_execution_config=False,\n)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "groupchat = GroupChat(\n",
+    "    agents=[user_proxy, researcher, writer, critic],\n",
+    "    messages=[],\n",
+    "    max_round=10,\n",
+    "    speaker_selection_method=\"auto\",  # Mistral selects the next speaker\n",
+    ")\n",
+    "\n",
+    "manager = GroupChatManager(\n",
+    "    groupchat=groupchat,\n",
+    "    llm_config=llm_config,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "result = user_proxy.run(\n    manager,\n    message=(\n        \"Write a brief overview of the current state of open-source AI models \"\n        \"in Europe, with a focus on Mistral AI's contributions.\"\n    ),\n)\nresult.process()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Summary\n\n| Pattern | AG2 Components | Use Case |\n|---------|---------------|----------|\n| Two-agent | `AssistantAgent` + `UserProxyAgent` | Simple Q&A, single tasks |\n| Function calling | `register_for_llm` + `register_for_execution` | Tool use, API calls |\n| Multi-agent | `GroupChat` + `GroupChatManager` | Complex workflows with specialists |\n\n### Key Takeaways\n\n- AG2 supports Mistral natively via `MistralLLMConfigEntry`\n- Function calling works out of the box with Mistral Large\n- GroupChat provides automatic multi-agent orchestration\n- No wrapper libraries needed — just `pip install ag2[openai] mistralai`\n\n### Resources\n\n- [AG2 Documentation](https://docs.ag2.ai/)\n- [AG2 GitHub](https://github.com/ag2ai/ag2)\n- [Mistral AI API Reference](https://docs.mistral.ai/)"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- Adds an [AG2](https://ag2.ai/) (formerly AutoGen) integration example in `third_party/AG2/`
- Demonstrates multi-agent orchestration with Mistral models via three progressive examples
- Updates root README third-party tools table with AG2 entry

## What's included
`third_party/AG2/ag2_multi_agent_mistral.ipynb` — Colab-compatible notebook with:
1. **Basic two-agent conversation** — `AssistantAgent` + `UserProxyAgent` with Mistral
2. **Function calling** — AG2's dual registration pattern (`register_for_llm` + `register_for_execution`)
3. **Multi-agent GroupChat** — automatic speaker selection with specialist agents

## How it differs from MS_Autogen_pgsql
The existing `third_party/MS_Autogen_pgsql/` example uses Microsoft AutoGen (the original project).
AG2 is the community-maintained fork with:
- Active development (500K+ monthly PyPI downloads)
- Native Mistral support via `MistralLLMConfigEntry`
- GroupChat multi-agent orchestration
- `pip install ag2` (separate package from Microsoft's `autogen-agentchat`)

## Test Plan
- [x] Notebook runs in Google Colab
- [x] `pre-commit run detect-private-key --all-files` passes
- [x] No hardcoded API keys
- [x] All Mistral API calls use `os.getenv("MISTRAL_API_KEY")`
- [x] Pinned package versions
- [x] Root README table updated
- [x] Existing examples untouched