### PR TITLE
Add SimpleFunctions: world-aware agent with prediction market data

### DIFF
--- a/third_party/SimpleFunctions/world_aware_agent.ipynb
+++ b/third_party/SimpleFunctions/world_aware_agent.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Building a World-Aware Agent with Mistral\n",
+    "\n",
+    "**Author:** [Patrick Liu](https://github.com/patrickliu0077), SimpleFunctions\n",
+    "\n",
+    "LLMs have a knowledge cutoff. This cookbook shows how to give Mistral models **real-time world awareness** by injecting calibrated prediction market data — probabilities backed by real money from 9,706 contracts.\n",
+    "\n",
+    "We use [SimpleFunctions](https://simplefunctions.dev/world) to inject ~800 tokens of structured world state (geopolitics, economy, energy, elections, crypto, tech) into the system prompt. No API key needed.\n",
+    "\n",
+    "**What you'll build:**\n",
+    "1. System prompt injection with live world state\n",
+    "2. Function calling for market search and topic drilling\n",
+    "3. An agentic loop that uses prediction market data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install mistralai requests -q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "import requests\n",
+    "from mistralai import Mistral\n",
+    "\n",
+    "client = Mistral(api_key=os.environ[\"MISTRAL_API_KEY\"])\n",
+    "MODEL = \"mistral-large-latest\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Fetch the World State\n",
+    "\n",
+    "One API call. ~800 tokens of markdown. Anchor contracts (recession, Fed rate, Iran invasion) always appear. Updated every 15 minutes from Kalshi (CFTC-regulated) and Polymarket."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "world = requests.get(\"https://simplefunctions.dev/api/agent/world\").text\n",
+    "print(world)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: World-Aware Mistral via System Prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = f\"\"\"You are a macro research analyst with real-time world awareness.\n",
+    "\n",
+    "Use the data below as ground truth. Cite specific probabilities and prices.\n",
+    "Do not hallucinate numbers — if it's not in the data, say you don't know.\n",
+    "\n",
+    "{world}\"\"\"\n",
+    "\n",
+    "response = client.chat.complete(\n",
+    "    model=MODEL,\n",
+    "    messages=[\n",
+    "        {\"role\": \"system\", \"content\": system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": \"What's the current geopolitical risk level and how does it affect energy markets?\"},\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "print(response.choices[0].message.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Function Calling for Deeper Data\n",
+    "\n",
+    "Define tools so Mistral can search specific markets and get focused world state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tools = [\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"function\": {\n",
+    "            \"name\": \"get_world_state\",\n",
+    "            \"description\": \"Get current world state from prediction markets. Focus on specific topics for deeper coverage with the same token budget.\",\n",
+    "            \"parameters\": {\n",
+    "                \"type\": \"object\",\n",
+    "                \"properties\": {\n",
+    "                    \"focus\": {\n",
+    "                        \"type\": \"string\",\n",
+    "                        \"description\": \"Comma-separated topics: geopolitics, economy, energy, elections, crypto, tech\"\n",
+    "                    }\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "    },\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"function\": {\n",
+    "            \"name\": \"get_world_delta\",\n",
+    "            \"description\": \"Get only what changed in the world since a time. ~30-50 tokens vs 800 for full state.\",\n",
+    "            \"parameters\": {\n",
+    "                \"type\": \"object\",\n",
+    "                \"properties\": {\n",
+    "                    \"since\": {\"type\": \"string\", \"description\": \"Time window: 30m, 1h, 6h, 24h\"}\n",
+    "                },\n",
+    "                \"required\": [\"since\"]\n",
+    "            }\n",
+    "        }\n",
+    "    },\n",
+    "    {\n",
+    "        \"type\": \"function\",\n",
+    "        \"function\": {\n",
+    "            \"name\": \"search_prediction_markets\",\n",
+    "            \"description\": \"Search prediction markets for specific contracts. Returns prices, volumes, spreads.\",\n",
+    "            \"parameters\": {\n",
+    "                \"type\": \"object\",\n",
+    "                \"properties\": {\n",
+    "                    \"query\": {\"type\": \"string\", \"description\": \"Search query, e.g. 'iran oil' or 'fed rate cut'\"}\n",
+    "                },\n",
+    "                \"required\": [\"query\"]\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "]\n",
+    "\n",
+    "\n",
+    "def execute_tool(name, args):\n",
+    "    if name == \"get_world_state\":\n",
+    "        url = \"https://simplefunctions.dev/api/agent/world\"\n",
+    "        if args.get(\"focus\"):\n",
+    "            url += f\"?focus={args['focus']}\"\n",
+    "        return requests.get(url).text\n",
+    "    elif name == \"get_world_delta\":\n",
+    "        return requests.get(f\"https://simplefunctions.dev/api/agent/world/delta?since={args['since']}\").text\n",
+    "    elif name == \"search_prediction_markets\":\n",
+    "        resp = requests.get(f\"https://simplefunctions.dev/api/public/scan?q={args['query']}&limit=10\")\n",
+    "        return json.dumps(resp.json().get(\"markets\", [])[:10], indent=2)\n",
+    "    return \"Unknown tool\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Agentic loop with function calling\n",
+    "messages = [\n",
+    "    {\"role\": \"system\", \"content\": system_prompt},\n",
+    "    {\"role\": \"user\", \"content\": \"Search for Iran-related contracts and analyze the risk of oil supply disruption.\"},\n",
+    "]\n",
+    "\n",
+    "while True:\n",
+    "    response = client.chat.complete(\n",
+    "        model=MODEL,\n",
+    "        messages=messages,\n",
+    "        tools=tools,\n",
+    "    )\n",
+    "\n",
+    "    msg = response.choices[0].message\n",
+    "\n",
+    "    if msg.tool_calls:\n",
+    "        messages.append(msg)\n",
+    "        for tc in msg.tool_calls:\n",
+    "            args = json.loads(tc.function.arguments) if isinstance(tc.function.arguments, str) else tc.function.arguments\n",
+    "            result = execute_tool(tc.function.name, args)\n",
+    "            print(f\"Tool: {tc.function.name}({args})\")\n",
+    "            messages.append({\n",
+    "                \"role\": \"tool\",\n",
+    "                \"name\": tc.function.name,\n",
+    "                \"content\": result,\n",
+    "                \"tool_call_id\": tc.id,\n",
+    "            })\n",
+    "    else:\n",
+    "        print(\"\\n\" + msg.content)\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Why Prediction Markets?\n",
+    "\n",
+    "| | Web Search | News API | Prediction Markets |\n",
+    "|---|---|---|---|\n",
+    "| **Output** | Narrative text | Headlines | Calibrated probabilities |\n",
+    "| **Token cost** | 2,000-5,000 | 500-1,000 | ~800 for everything |\n",
+    "| **Latency** | 2-5 seconds | 500ms | ~200ms (cached) |\n",
+    "| **Calibration** | None | None | Participants lose money when wrong |\n",
+    "\n",
+    "A price of 53c on \"Iran invasion\" encodes the aggregate judgment of everyone with money at risk on that question.\n",
+    "\n",
+    "**Links:**\n",
+    "- [World State API](https://simplefunctions.dev/api/agent/world) — try it now (no auth)\n",
+    "- [Documentation](https://simplefunctions.dev/docs/guide)\n",
+    "- [All endpoints](https://simplefunctions.dev/api/tools)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Adds a third-party integration showing how to build a world-aware Mistral agent using calibrated prediction market data from SimpleFunctions.

## What's Included

`third_party/SimpleFunctions/world_aware_agent.ipynb` — covers:

1. **System prompt injection** — ~800 tokens of real-time world state from 9,706 prediction markets (Kalshi + Polymarket)
2. **Function calling** — tools for focused topic drilling, incremental updates, and market search
3. **Agentic loop** — full function-calling cycle with Mistral calling prediction market tools

## Why

LLMs have a knowledge cutoff. Web search returns narratives ("tensions remain elevated"), not data. Prediction markets return calibrated probabilities backed by real money — a fundamentally different data source.

The world state endpoint is free, requires no API key, and returns ~800 tokens updated every 15 minutes.

**Author:** Patrick Liu ([@patrickliu0077](https://github.com/patrickliu0077)), SimpleFunctions