### PR TITLE
feat(obs): add observability cookbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [moderation_classifier.ipynb](mistral/classifier_factory/moderation_classifier.ipynb) | fine-tuning, classifier | Fine-tuning a classifier for moderation. |
 | [pixtral_finetune_on_satellite_data.ipynb](mistral/fine_tune/pixtral_finetune_on_satellite_data.ipynb) | fine-tuning, image processing, batch | Fine-tuning a Pixtral-12B for satellite images classification. |
 | [sts_demo.py](mistral/tts/sts_demo.py) | chat, tts | STT -> LLM -> TTS Demo. |
+| [llm_judge_campaign_workflow.ipynb](mistral/observability/llm_judge_campaign_workflow.ipynb) | observability, evaluation | Run campaigns with LLM judges to classify agent behaviors at scale |
+| [manage_datasets.ipynb](mistral/observability/manage_datasets.ipynb) | observability, datasets | Create and manage datasets for evaluation or fine-tuning |
 
 
 

--- a/mistral/observability/data/dataset-import-example.jsonl
+++ b/mistral/observability/data/dataset-import-example.jsonl
@@ -1,0 +1,2 @@
+{"messages": [{"role": "user", "content": "How do I reset my password?"}, {"role": "assistant", "content": "You can reset your password by..."}]}
+{"messages": [{"role": "user", "content": "What's the weather like in Paris?"}], "properties": {"grading_guindance": "The agent should perform a web search to find the current weather in Paris."}}

--- a/mistral/observability/llm_judge_campaign_workflow.ipynb
+++ b/mistral/observability/llm_judge_campaign_workflow.ipynb
@@ -1,0 +1,223 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Running Campaigns with LLM Judges using Mistral Observability API\n",
+    "\n",
+    "## **Objective**\n",
+    "Use campaigns and LLM judges to automatically detect and analyze specific agent behaviors (e.g., excessive apologies) across a timeframe. This workflow demonstrates how to classify agent events at scale using LLM-based criteria, filter datasets, and build evaluation suites.\n",
+    "\n",
+    "## **Prerequisites**\n",
+    "\n",
+    "1. **Installation:** Install the `mistralai` package (see below).\n",
+    "2. **API Key:** [Get yours here](https://console.mistral.ai/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install mistralai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Workflow**\n",
+    "\n",
+    "### **1. Initialize the Client**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mistralai.client import Mistral\n",
+    "from getpass import getpass\n",
+    "\n",
+    "api_key = getpass(\"Enter Mistral AI API Key\")\n",
+    "mistral = Mistral(api_key=api_key)\n",
+    "print(\"✅ Client ready\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### **2. Search for Agent Events**\n\n**Note:** This example filters by agent ID and timestamp, but many other search parameters are available. To see all available fields, use `mistral.beta.observability.chat_completion_events.fields.list()`.\n\nThe `search()` method supports pagination via `page_size` and `cursor` parameters. See the `manage_datasets.ipynb` cookbook for detailed pagination examples."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "agent_id = \"ag_00000000000000000000000000000000\"  # Your agent ID\ntime_range = {\n    \"start\": \"2026-01-02T03:39:00.000Z\",  # ISO 8601 format\n    \"end\":   \"2026-04-08T15:39:00.000Z\",\n}\n\nsearch_params = {\n    \"filters\": {\n        \"AND\": [\n            {\"field\": \"api_agent_id\", \"op\": \"eq\", \"value\": agent_id},\n            {\n                \"AND\": [\n                    {\"field\": \"timestamp\", \"op\": \"gte\", \"value\": time_range[\"start\"]},\n                    {\"field\": \"timestamp\", \"op\": \"lte\", \"value\": time_range[\"end\"]},\n                ]\n            },\n        ]\n    }\n}\n\nresponse = mistral.beta.observability.chat_completion_events.search(\n    search_params=search_params,\n    page_size=25  # Limit to 25 events per page\n)\n\nevents = response.completion_events.results\nprint(f\"✓ Found {len(events)} event(s)\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **3. Create an LLM Judge**\n",
+    "\n",
+    "A **judge** is an evaluator that assesses the quality or characteristics of agent responses. Judges can be one of two types:\n",
+    "\n",
+    "- **Classification Judge**: Assigns categorical labels to responses (e.g., \"apology\" / \"no-apology\", \"helpful\" / \"not-helpful\")\n",
+    "- **Regression Judge** (also called **Scoring Judge**): Assigns numerical scores to responses (e.g., a score from 1-5 for quality)\n",
+    "\n",
+    "In this example, we'll create a classification judge to detect apologies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "judge = mistral.beta.observability.judges.create(\n    name=\"Apology Detector\",\n    description=\"Classifies if the agent apologized (e.g., 'I'm sorry')\",\n    model_name=\"mistral-large-latest\",\n    output={\n        \"type\": \"CLASSIFICATION\",\n        \"options\": [\n            {\"value\": \"no-apology\", \"description\": \"No apology detected\"},\n            {\"value\": \"apology\",    \"description\": \"Apology detected\"},\n        ],\n    },\n    instructions=\"\"\"Analyze the assistant's response.\nReturn 'apology' if it contains explicit apologies (e.g., 'I'm sorry', 'I apologize').\nOtherwise, return 'no-apology'.\"\"\",\n    tools=[],\n)\nprint(\"✓ Judge created\")\nprint(f\"View at: https://console.mistral.ai/observability/judges/{judge.id}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note:**\n",
+    "\n",
+    "- Use `CLASSIFICATION` for discrete labels (e.g., \"apology\" / \"no-apology\").\n",
+    "- For numerical ratings (e.g., 1-5), use `REGRESSION`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **4. Run a Campaign**\n",
+    "\n",
+    "A **campaign** applies a judge to a filtered set of completion events asynchronously. Campaigns are ideal for analyzing agent behavior at scale across thousands of events."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "campaign = mistral.beta.observability.campaigns.create(\n",
+    "    name=\"Apology Detection Campaign\",\n",
+    "    description=f\"Classify apologies for agent {agent_id} ({time_range['start']} to {time_range['end']})\",\n",
+    "    judge_id=judge.id,\n",
+    "    search_params=search_params,\n",
+    "    max_nb_events=10,  # Max events to process, the upper bound is 10000\n",
+    ")\n",
+    "print(\"✓ Campaign created\")\n",
+    "print(f\"Monitor at: https://console.mistral.ai/observability/campaigns/{campaign.id}\")\n",
+    "print(\"⚠️ Campaigns run asynchronously. Wait for completion before proceeding.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Tip:**\n",
+    "\n",
+    "- Campaigns may take minutes to hours depending on event volume.\n",
+    "- Check status via the console link or programmatically (see next step)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **5. Check Campaign Status**\n",
+    "\n",
+    "Re-run this cell until `status == \"COMPLETED\"`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "status = mistral.beta.observability.campaigns.fetch_status(\n",
+    "    campaign_id=campaign.id\n",
+    ")\n",
+    "print(f\"🔄 Status: {status.status}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **6. Filter Events by Classification**\n",
+    "\n",
+    "Once complete, filter events using the judge's output field:  \n",
+    "`__judge_{judge_id_without_hyphens}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_params = {\n",
+    "    \"filters\": {\n",
+    "        \"AND\": [\n",
+    "            *search_params[\"filters\"][\"AND\"],  # Original filters\n",
+    "            {\n",
+    "                \"field\": f\"__judge_{judge.id.replace('-', '')}\",\n",
+    "                \"op\": \"eq\",\n",
+    "                \"value\": \"no-apology\",  # Only events with apologies\n",
+    "            },\n",
+    "        ]\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "filtered_response = mistral.beta.observability.chat_completion_events.search(search_params=filtered_params)\n",
+    "filtered_events = filtered_response.completion_events.results\n",
+    "\n",
+    "print(f\"📊 Found {len(filtered_events)} apology event(s)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Summary**\n",
+    "\n",
+    "This notebook demonstrates how to use campaigns and LLM judges to classify agent events at scale:\n",
+    "\n",
+    "1. **Search for agent events** within a specific timeframe\n",
+    "2. **Create an LLM judge** with classification criteria (e.g., \"apology\" / \"no-apology\")\n",
+    "3. **Run a campaign** to apply the judge to all matching events asynchronously\n",
+    "4. **Monitor campaign status** until completion\n",
+    "5. **Filter events** by classification results for further analysis"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/mistral/observability/manage_datasets.ipynb
+++ b/mistral/observability/manage_datasets.ipynb
@@ -1,0 +1,448 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dataset Management with Mistral Observability API\n",
+    "\n",
+    "## **Objective**  \n",
+    "Create and manage datasets for evaluation or fine-tuning using the Mistral Observability API. This notebook demonstrates multiple methods for populating datasets with conversation records.\n",
+    "\n",
+    "## **Prerequisites**\n",
+    "\n",
+    "1. **Installation:** Install the `mistralai` package (see below).\n",
+    "2. **API Key:** [Get yours here](https://console.mistral.ai/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install mistralai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **What is a Dataset?**\n",
+    "\n",
+    "A **dataset** is a collection of conversation records used for evaluation or fine-tuning. Each dataset contains:\n",
+    "\n",
+    "- **Records**: Individual conversation examples\n",
+    "- **Metadata**: Dataset name and description\n",
+    "\n",
+    "### **Record Structure**\n",
+    "\n",
+    "Each record in a dataset contains:\n",
+    "\n",
+    "- **Payload**: The conversation data following the [Chat Completion API format](https://docs.mistral.ai/capabilities/completion/usage)\n",
+    "  - **Messages**: A list of chat messages with `role` and `content` fields\n",
+    "    - Roles: `\"user\"`, `\"assistant\"`, `\"system\"`\n",
+    "    - Content: Can be a string (simple text) or a list of chunks (multimodal content)\n",
+    "  \n",
+    "  **Example payload:**\n",
+    "  ```json\n",
+    "  {\n",
+    "    \"messages\": [\n",
+    "      {\"role\": \"user\", \"content\": \"What is the capital of France?\"},\n",
+    "      {\"role\": \"assistant\", \"content\": \"The capital of France is Paris.\"}\n",
+    "    ]\n",
+    "  }\n",
+    "  ```\n",
+    "\n",
+    "- **Properties** (optional): Custom metadata for the record (e.g. grading guidance, expected output...)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Workflow**\n",
+    "\n",
+    "### **1. Initialize the Client**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mistralai.client import Mistral\n",
+    "from getpass import getpass\n",
+    "\n",
+    "api_key = getpass(\"Enter Mistral AI API Key\")\n",
+    "mistral = Mistral(api_key=api_key)\n",
+    "print(\"✅ Client ready\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **2. Create a Dataset**\n",
+    "\n",
+    "Create a dataset with a name and description to organize your data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = mistral.beta.observability.datasets.create(\n",
+    "    name=\"Demo Dataset\",\n",
+    "    description=\"A sample dataset created to demonstrate the Mistral Observability API\"\n",
+    ")\n",
+    "\n",
+    "print(f\"Dataset created. View at: https://console.mistral.ai/observability/datasets/{dataset.id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **3. Add Records Manually**\n",
+    "\n",
+    "Best for small datasets or creating individual records with custom properties."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create first record\n",
+    "record1 = mistral.beta.observability.datasets.create_record(\n",
+    "    dataset_id=dataset.id,\n",
+    "    payload={\n",
+    "        \"messages\": [\n",
+    "            {\"role\": \"user\", \"content\": \"What is the capital of France?\"},\n",
+    "            {\"role\": \"assistant\", \"content\": \"The capital of France is Paris.\"},\n",
+    "        ]\n",
+    "    },\n",
+    "    properties={\"source\": \"demo_script\", \"priority\": \"high\"},\n",
+    ")\n",
+    "\n",
+    "print(\"✓ Record 1 created successfully!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create second record\n",
+    "record2 = mistral.beta.observability.datasets.create_record(\n",
+    "    dataset_id=dataset.id,\n",
+    "    payload={\n",
+    "        \"messages\": [\n",
+    "            {\"role\": \"user\", \"content\": \"What is 2 + 2?\"},\n",
+    "            {\"role\": \"assistant\", \"content\": \"2 + 2 equals 4.\"},\n",
+    "        ]\n",
+    "    },\n",
+    "    properties={\"expected_output\": \"4\"},\n",
+    ")\n",
+    "\n",
+    "print(\"✓ Record 2 created successfully!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **4. Import Records from JSONL File**\n",
+    "\n",
+    "Import multiple records from a JSONL file where each line is a valid JSON object with a `messages` field.\n",
+    "\n",
+    "**Example JSONL:**\n",
+    "```json\n",
+    "{\"messages\": [{\"role\": \"user\", \"content\": \"How do I reset my password?\"}, {\"role\": \"assistant\", \"content\": \"You can reset your password by...\"}]}\n",
+    "{\"messages\": [{\"role\": \"user\", \"content\": \"What's the weather like in Paris?\"}], \"properties\": {\"grading_guindance\": \"The agent should perform a web search to find the current weather in Paris.\"}}\n",
+    "```\n",
+    "\n",
+    "#### **4.1. Upload File**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file = mistral.files.upload(\n",
+    "    file={\n",
+    "        \"file_name\": \"dataset-import-example.jsonl\",\n",
+    "        \"content\": open(\"data/dataset-import-example.jsonl\", \"rb\"),\n",
+    "    },\n",
+    "    purpose=\"evaluation\",\n",
+    ")\n",
+    "print(f\"✓ File uploaded (id = {file.id})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **4.2. Import Records from File**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_import_task = mistral.beta.observability.datasets.import_from_file(\n",
+    "    dataset_id=dataset.id,\n",
+    "    file_id=file.id,\n",
+    ")\n",
+    "print(\"✓ File import task created\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **4.3. Check Import Status**\n",
+    "\n",
+    "Status `COMPLETED` means the import was successful."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_task = mistral.beta.observability.datasets.fetch_task(\n",
+    "    dataset_id=dataset.id, task_id=file_import_task.id\n",
+    ")\n",
+    "\n",
+    "print(f\"File import status: {file_task.status}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **5. Import Records from Campaign**\n",
+    "\n",
+    "Add records from an existing campaign to the dataset.\n",
+    "\n",
+    "#### **5.1. Create Import Task**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "campaign_import_task = mistral.beta.observability.datasets.import_from_campaign(\n    dataset_id=dataset.id,\n    campaign_id=\"00000000-0000-0000-0000-000000000000\",  # Replace with your campaign ID\n)\nprint(\"✓ Campaign import task created\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **5.2. Check Task Status**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "campaign_task = mistral.beta.observability.datasets.fetch_task(\n",
+    "    dataset_id=dataset.id, task_id=campaign_import_task.id\n",
+    ")\n",
+    "\n",
+    "print(f\"Campaign import status: {campaign_task.status}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **6. Import Records from Explorer**\n",
+    "\n",
+    "Add records by specifying completion event IDs from the [Explorer](https://console.mistral.ai/observability/explorer).\n",
+    "\n",
+    "#### **6.1. Create Import Task**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "explorer_import_task = (\n    mistral.beta.observability.datasets.import_from_explorer(\n        dataset_id=dataset.id,\n        completion_event_ids=[\"00000000-0000-0000-0000-000000000000\"],  # Replace with your event IDs\n    )\n)\nprint(\"✓ Explorer import task created\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **6.2. Check Task Status**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "explorer_task = mistral.beta.observability.datasets.fetch_task(\n",
+    "    dataset_id=dataset.id, task_id=explorer_import_task.id\n",
+    ")\n",
+    "\n",
+    "print(f\"Explorer import status: {explorer_task.status}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **7. List Records with Pagination**\n",
+    "\n",
+    "Retrieve records from the dataset with pagination support.\n",
+    "\n",
+    "#### **7.1. Fetch First Page**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "page = 1\n",
+    "page_size = 3  # Limit to 3 records per page for demonstration\n",
+    "\n",
+    "records_response = mistral.beta.observability.datasets.list_records(\n",
+    "    dataset_id=dataset.id,\n",
+    "    page_size=page_size,\n",
+    "    page=page\n",
+    ")\n",
+    "\n",
+    "print(f\"✓ Found {len(records_response.records.results)} record(s) on this page\")\n",
+    "print(f\"Total records: {records_response.records.count}\")\n",
+    "print(f\"Has more pages: {records_response.records.next is not None}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **7.2. Fetch Next Page (if available)**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if records_response.records.next is not None:\n",
+    "    page = 2  # Increment to next page\n",
+    "    \n",
+    "    # Fetch the next page using the page parameter\n",
+    "    next_page_response = mistral.beta.observability.datasets.list_records(\n",
+    "        dataset_id=dataset.id,\n",
+    "        page_size=page_size,\n",
+    "        page=page\n",
+    "    )\n",
+    "    \n",
+    "    print(f\"✓ Page {page}: Found {len(next_page_response.records.results)} record(s)\")\n",
+    "    print(f\"Has more pages: {next_page_response.records.next is not None}\")\n",
+    "else:\n",
+    "    print(\"No more pages available\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **7.3. Fetch All Records**\n",
+    "\n",
+    "To retrieve all records, iterate through all pages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_records = []\n",
+    "page = 1\n",
+    "\n",
+    "while True:\n",
+    "    response = mistral.beta.observability.datasets.list_records(\n",
+    "        dataset_id=dataset.id,\n",
+    "        page_size=25,  # Use larger page size for efficiency\n",
+    "        page=page\n",
+    "    )\n",
+    "    \n",
+    "    all_records.extend(response.records.results)\n",
+    "    print(f\"✓ Page {page}: Fetched {len(response.records.results)} record(s)\")\n",
+    "    \n",
+    "    if response.records.next is None:\n",
+    "        break\n",
+    "    \n",
+    "    page += 1\n",
+    "\n",
+    "print(f\"\\n✓ Retrieved all {len(all_records)} record(s) from the dataset across {page} page(s)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## **Summary**\n",
+    "\n",
+    "This notebook demonstrates how to create and populate datasets using the Mistral Observability API:\n",
+    "\n",
+    "1. **Create a dataset** with a name and description\n",
+    "2. **Add records manually** for individual records with custom properties\n",
+    "3. **Import from JSONL file** for bulk imports from structured files\n",
+    "4. **Import from campaign** to reuse existing campaign data\n",
+    "5. **Import from Explorer** to select specific completion events\n",
+    "6. **List records** to verify and review dataset contents\n",
+    "\n",
+    "Datasets created this way can be used for:\n",
+    "- Running evaluations (see the evaluation workflow cookbooks)\n",
+    "- Fine-tuning models\n",
+    "- Building test suites\n",
+    "- Organizing conversation examples with metadata"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION


# Cookbook Pull Request

## Description

Add two new observability cookbooks under `mistral/observability/`:

- **llm_judge_campaign_workflow.ipynb**: End-to-end workflow for running campaigns with LLM judges — search for agent events, create a classification judge, run a campaign at scale, and filter results by classification output.
- **manage_datasets.ipynb**: Dataset management cookbook — create datasets, add records manually, import from JSONL  files/campaigns/Explorer, and paginate through records.

Both notebooks use the public mistralai SDK (mistral.beta.observability.* APIs).

## Type of Change

What type of PR is it?

- [x] New Cookbook
  - [x] Notebook File
    - [ ] Does it work on google colab?
  - [ ] Markdown File
- [ ] Cookbook Update
  - [ ] Code Refactoring
  - [ ] Bug Fix
- [ ] README.md Update
___
- [ ] Other (please describe):

## Cookbook Checklist:

- [x] My code is easy to read and well structured.
- [x] I've tagged the versions of any dependency required.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or errors.
___
- [ ] My changes do not concern the cookbooks.

## README.md Checklist

- [x] I've added my cookbook to the table.
___
- [ ] My changes do not concern the README file.

## Additional Context

These cookbooks document the observability APIs (judges, campaigns, datasets) available through `mistral.beta.observability`. A sample JSONL file is included under `mistral/observability/data/` for the dataset import example.