### PR TITLE
feat: add connector cookbooks

### DIFF
--- a/mistral/connectors/01-connectors-management.md
+++ b/mistral/connectors/01-connectors-management.md
@@ -1,0 +1,819 @@
+# Connectors Management Cookbook
+
+Create, retrieve, update, list, and delete MCP connectors using the Mistral AI SDK.
+
+> **API status:** The connectors API is accessed via `client.beta.connectors`. This is a **beta** endpoint and may change.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Recipes](#recipes)
+  - [1. Initialize the Client](#1-initialize-the-client)
+  - [2. Create a Connector](#2-create-a-connector)
+  - [3. Get a Connector](#3-get-a-connector)
+  - [4. List Connectors with Pagination and Filters](#4-list-connectors-with-pagination-and-filters)
+  - [5. Update a Connector](#5-update-a-connector)
+  - [6. Delete a Connector](#6-delete-a-connector)
+  - [7. Full Lifecycle — Create, Verify, Update, and Clean Up](#7-full-lifecycle--create-verify-update-and-clean-up)
+- [Python / TypeScript Naming Conventions](#python--typescript-naming-conventions)
+- [Troubleshooting](#troubleshooting)
+- [Error Codes Reference](#error-codes-reference)
+
+---
+
+## Prerequisites
+
+### Install
+
+```bash
+# Python
+pip install mistralai
+# or with uv
+uv add mistralai
+```
+
+```bash
+# TypeScript
+pnpm add @mistralai/mistralai
+```
+
+### Required environment variables
+
+Create a `.env` file at your project root:
+
+```bash
+MISTRAL_API_KEY=your-mistral-api-key
+```
+
+Get your API key from the [Mistral AI dashboard](https://console.mistral.ai/).
+
+---
+
+## Recipes
+
+---
+
+### 1. Initialize the Client
+
+**Prereqs:** `MISTRAL_API_KEY` set in your environment or `.env` file.
+
+**Python:**
+
+```python
+import os
+from mistralai import Mistral
+
+client = Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: process.env.MISTRAL_API_KEY });
+```
+
+**curl:**
+
+```bash
+# All subsequent curl examples assume these variables are set:
+export MISTRAL_API_KEY="your-api-key"
+export BASE_URL="https://api.mistral.ai"
+```
+
+**Output:** None — the client is ready to use.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | Invalid API key | Regenerate your key on the Mistral dashboard |
+
+---
+
+### 2. Create a Connector
+
+**Goal:** Register a new MCP connector that can later be used in conversations and agents.
+
+**When to use:**
+- You want to connect an external MCP server (e.g., DeepWiki, a custom tool server) to Mistral.
+- First step before using a custom connector in conversations.
+
+**Prereqs:** An initialized `client` ([Recipe 1](#1-initialize-the-client)).
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    connector = await client.beta.connectors.create_async(
+        name="my_deepwiki",
+        description="DeepWiki MCP connector for code repository exploration",
+        server="https://mcp.deepwiki.com/mcp",
+        visibility="shared_workspace",
+    )
+
+    print(f"ID:          {connector.id}")
+    print(f"Name:        {connector.name}")
+    print(f"Description: {connector.description}")
+    print(f"Server URL:  {connector.server}")
+    print(f"Auth type:  {connector.auth_type}")
+    print(f"Created at:  {connector.created_at}")
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const connector = await client.beta.connectors.create({
+    name: "my_deepwiki",
+    description: "DeepWiki MCP connector for code repository exploration",
+    server: "https://mcp.deepwiki.com/mcp",
+    visibility: "shared_workspace",
+  });
+
+  console.log(`ID:          ${connector.id}`);
+  console.log(`Name:        ${connector.name}`);
+  console.log(`Description: ${connector.description}`);
+  console.log(`Server URL:  ${connector.server}`);
+  console.log(`Auth type:  ${connector.auth_type}`);
+  console.log(`Created at:  ${connector.createdAt}`);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "${BASE_URL}/v1/connectors" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my_deepwiki",
+    "description": "DeepWiki MCP connector for code repository exploration",
+    "server": "https://mcp.deepwiki.com/mcp",
+    "visibility": "shared_workspace"
+  }'
+```
+
+**Output:**
+
+```
+ID:          a1b2c3d4-5678-90ab-cdef-1234567890ab
+Name:        my_deepwiki
+Description: DeepWiki MCP connector for code repository exploration
+Created at:  2026-02-24 10:30:00
+```
+
+**How it works:**
+- The connector registers an MCP server URL with Mistral's backend.
+- `visibility` controls who can use the connector:
+  - `private` — only the creator
+  - `shared_workspace` — anyone in the same workspace
+  - `shared_org` — anyone in the organization
+- The `name` must be unique within your scope and serves as a human-readable identifier.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `409 Conflict` | A connector with this name already exists | Choose a different name or delete the existing one first |
+| `422 Unprocessable Entity` | Invalid server URL or missing fields | Verify the MCP server URL is reachable |
+
+---
+
+### 3. Get a Connector
+
+**Goal:** Retrieve a connector's details by ID or by name.
+
+**When to use:**
+- Verifying a connector exists and checking its current configuration.
+- Looking up a connector ID when you only know the name.
+
+**Prereqs:** An existing connector.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    # Get by name
+    connector = await client.beta.connectors.get_async(
+        connector_id_or_name="my_deepwiki"
+    )
+    print(f"Name:        {connector.name}")
+    print(f"ID:          {connector.id}")
+    print(f"Description: {connector.description}")
+
+    # Get by ID (equivalent)
+    connector_by_id = await client.beta.connectors.get_async(
+        connector_id_or_name=str(connector.id)
+    )
+    assert connector_by_id.name == connector.name
+    print(f"\nVerified: get-by-name and get-by-ID return the same connector.")
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  // Get by name
+  const connector = await client.beta.connectors.get({
+    connectorIdOrName: "my_deepwiki",
+  });
+  console.log(`Name:        ${connector.name}`);
+  console.log(`ID:          ${connector.id}`);
+  console.log(`Description: ${connector.description}`);
+
+  // Get by ID (equivalent)
+  const connectorById = await client.beta.connectors.get({
+    connectorIdOrName: connector.id,
+  });
+  console.assert(connectorById.name === connector.name);
+  console.log(`\nVerified: get-by-name and get-by-ID return the same connector.`);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+# By name
+curl -X GET "${BASE_URL}/v1/connectors/my_deepwiki" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}"
+
+# By ID
+curl -X GET "${BASE_URL}/v1/connectors/a1b2c3d4-5678-90ab-cdef-1234567890ab" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}"
+```
+
+**Output:**
+
+```
+Name:        my_deepwiki
+ID:          a1b2c3d4-5678-90ab-cdef-1234567890ab
+Description: DeepWiki MCP connector for code repository exploration
+
+Verified: get-by-name and get-by-ID return the same connector.
+```
+
+**How it works:**
+- The `connector_id_or_name` parameter accepts either a UUID string or the connector's unique name.
+- Returns the full connector object including `id`, `name`, `description`, `created_at`, and server configuration.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `404 Not Found` | Connector doesn't exist or was deleted | Verify the name/ID with [Recipe 4](#4-list-connectors-with-pagination-and-filters) |
+
+---
+
+### 4. List Connectors with Pagination and Filters
+
+**Goal:** Retrieve all your connectors with cursor-based pagination and optional filters.
+
+**When to use:**
+- Discovering which connectors are available in your workspace.
+- Building a UI that lists connectors.
+- Auditing active vs. inactive connectors.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def list_all_connectors() -> None:
+    # First page
+    page = await client.beta.connectors.list_async(page_size=10)
+    all_connectors = list(page.items)
+
+    print(f"Page 1: {len(page.items)} connectors")
+    for c in page.items:
+        print(f"  - {c.name} ({c.id})")
+
+    # Fetch remaining pages
+    while page.pagination.next_cursor:
+        page = await client.beta.connectors.list_async(
+            page_size=10,
+            cursor=page.pagination.next_cursor,
+        )
+        all_connectors.extend(page.items)
+        print(f"Next page: {len(page.items)} connectors")
+
+    print(f"\nTotal: {len(all_connectors)} connectors")
+
+
+async def list_active_only() -> None:
+    active = await client.beta.connectors.list_async(
+        page_size=20,
+        query_filters={"active": True},
+    )
+    print(f"\nActive connectors: {len(active.items)}")
+    for c in active.items:
+        print(f"  - {c.name}")
+
+
+async def main() -> None:
+    await list_all_connectors()
+    await list_active_only()
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function listAllConnectors(): Promise<void> {
+  // First page
+  let page = await client.beta.connectors.list({ pageSize: 10 });
+  const allConnectors = [...(page.items ?? [])];
+
+  console.log(`Page 1: ${(page.items ?? []).length} connectors`);
+  for (const c of page.items ?? []) {
+    console.log(`  - ${c.name} (${c.id})`);
+  }
+
+  // Fetch remaining pages
+  while (page.pagination?.nextCursor) {
+    page = await client.beta.connectors.list({
+      pageSize: 10,
+      cursor: page.pagination.nextCursor,
+    });
+    allConnectors.push(...(page.items ?? []));
+    console.log(`Next page: ${(page.items ?? []).length} connectors`);
+  }
+
+  console.log(`\nTotal: ${allConnectors.length} connectors`);
+}
+
+async function listActiveOnly(): Promise<void> {
+  const active = await client.beta.connectors.list({
+    pageSize: 20,
+    queryFilters: { active: true },
+  });
+  console.log(`\nActive connectors: ${(active.items ?? []).length}`);
+  for (const c of active.items ?? []) {
+    console.log(`  - ${c.name}`);
+  }
+}
+
+async function main(): Promise<void> {
+  await listAllConnectors();
+  await listActiveOnly();
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+# First page
+curl -X GET "${BASE_URL}/v1/connectors?page_size=10" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}"
+
+# Next page (use next_cursor from previous response)
+curl -X GET "${BASE_URL}/v1/connectors?page_size=10&cursor=<next_cursor>" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}"
+
+# Active connectors only
+curl -X GET "${BASE_URL}/v1/connectors?page_size=20&query_filters=%7B%22active%22%3Atrue%7D" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}"
+```
+
+**Output:**
+
+```
+Page 1: 10 connectors
+  - my_deepwiki (a1b2c3d4-...)
+  - gmail_connector (b2c3d4e5-...)
+  ...
+Next page: 5 connectors
+
+Total: 15 connectors
+
+Active connectors: 12
+  - my_deepwiki
+  - gmail_connector
+  ...
+```
+
+**How it works:**
+- Pagination is cursor-based. `next_cursor` is `None` / `undefined` when there are no more pages.
+- `page_size` controls how many items per page.
+- `query_filters` accepts a dictionary — currently supports `{"active": True}` to filter active connectors.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `400 Bad Request` | Invalid cursor value | Don't reuse cursors across different filter queries |
+
+---
+
+### 5. Update a Connector
+
+**Goal:** Modify an existing connector's name, description, or server URL.
+
+**When to use:**
+- Fixing a typo in the description.
+- Pointing a connector to a new MCP server version.
+- Renaming a connector.
+
+**Prereqs:** An existing connector ID (UUID).
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    connector_id = "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+
+    # Update description only
+    updated = await client.beta.connectors.update_async(
+        connector_id=connector_id,
+        description="Updated: DeepWiki connector for code exploration",
+    )
+    print(f"New description: {updated.description}")
+
+    # Update name
+    updated = await client.beta.connectors.update_async(
+        connector_id=connector_id,
+        name="my_deepwiki_v2",
+    )
+    print(f"New name: {updated.name}")
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const connectorId = "a1b2c3d4-5678-90ab-cdef-1234567890ab";
+
+  // Update description only
+  let updated = await client.beta.connectors.update({
+    connectorId,
+    connectorMCPUpdate: {
+      description: "Updated: DeepWiki connector for code exploration",
+    },
+  });
+  console.log(`New description: ${updated.description}`);
+
+  // Update name
+  updated = await client.beta.connectors.update({
+    connectorId,
+    connectorMCPUpdate: {
+      name: "my_deepwiki_v2",
+    },
+  });
+  console.log(`New name: ${updated.name}`);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X PATCH "${BASE_URL}/v1/connectors/${CONNECTOR_ID}" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"description": "Updated: DeepWiki connector for code exploration"}'
+```
+
+**Output:**
+
+```
+New description: Updated: DeepWiki connector for code exploration
+New name: my_deepwiki_v2
+```
+
+**How it works:**
+- `update` performs a partial update — only the provided fields are changed.
+- The `connector_id` parameter must be the UUID (not the name).
+- Returns the full updated connector object.
+
+> **Note (TypeScript):** The update method wraps the fields to change inside a `connectorMCPUpdate` object. See the [naming conventions table](#python--typescript-naming-conventions) for more differences.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `404 Not Found` | Invalid connector ID | The connector may have been deleted |
+| `409 Conflict` / `500 Internal Server Error` | New name conflicts with an existing connector | Choose a different name |
+
+---
+
+### 6. Delete a Connector
+
+**Goal:** Remove a connector that is no longer needed.
+
+**When to use:**
+- Cleaning up test connectors.
+- Decommissioning an integration.
+
+**Prereqs:** The connector ID (UUID) you want to delete.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    connector_id = "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+
+    # Delete
+    result = await client.beta.connectors.delete_async(
+        connector_id=connector_id,
+    )
+    print(f"Delete response: {result.message}")
+
+    # Verify deletion
+    try:
+        await client.beta.connectors.get_async(
+            connector_id_or_name=connector_id
+        )
+        print("ERROR: Connector still exists!")
+    except Exception as e:
+        print(f"Confirmed deleted: {type(e).__name__}")
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const connectorId = "a1b2c3d4-5678-90ab-cdef-1234567890ab";
+
+  // Delete
+  const result = await client.beta.connectors.delete({
+    connectorId,
+  });
+  console.log(`Delete response: ${result.message}`);
+
+  // Verify deletion
+  try {
+    await client.beta.connectors.get({
+      connectorIdOrName: connectorId,
+    });
+    console.log("ERROR: Connector still exists!");
+  } catch (e: any) {
+    console.log(`Confirmed deleted: ${e.constructor.name}`);
+  }
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X DELETE "${BASE_URL}/v1/connectors/${CONNECTOR_ID}" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}"
+```
+
+**Output:**
+
+```
+Delete response: Connector deleted successfully
+Confirmed deleted: NotFoundError
+```
+
+**How it works:**
+- Deletion is **permanent** — the connector cannot be recovered.
+- Any agents referencing this connector will lose access to its tools.
+- The `connector_id` must be the UUID string.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `404 Not Found` | Connector already deleted or wrong ID | No action needed |
+
+---
+
+### 7. Full Lifecycle — Create, Verify, Update, and Clean Up
+
+**Goal:** End-to-end workflow demonstrating all connector operations in sequence.
+
+**When to use:**
+- Integration tests.
+- Ephemeral connectors for one-off tasks.
+- Template for production connector management.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    connector_id: str | None = None
+
+    try:
+        # 1. Create
+        connector = await client.beta.connectors.create_async(
+            name="lifecycle_test",
+            description="Ephemeral connector for testing",
+            server="https://mcp.deepwiki.com/mcp",
+            visibility="private",
+        )
+        connector_id = str(connector.id)
+        print(f"Created: {connector.name} ({connector.id})")
+
+        # 2. Get — verify it exists
+        fetched = await client.beta.connectors.get_async(
+            connector_id_or_name="lifecycle_test"
+        )
+        print(f"Fetched: {fetched.name} — {fetched.description}")
+
+        # 3. List — find it in the list
+        page = await client.beta.connectors.list_async(page_size=50)
+        names = [c.name for c in page.items]
+        assert "lifecycle_test" in names
+        print(f"Listed: found among {len(page.items)} connectors")
+
+        # 4. Update — change description
+        updated = await client.beta.connectors.update_async(
+            connector_id=connector_id,
+            description="Updated description for lifecycle test",
+        )
+        print(f"Updated: {updated.description}")
+
+        # 5. Delete
+        result = await client.beta.connectors.delete_async(
+            connector_id=connector_id,
+        )
+        print(f"Deleted: {result.message}")
+        connector_id = None
+
+        # 6. Verify deletion
+        try:
+            await client.beta.connectors.get_async(
+                connector_id_or_name="lifecycle_test"
+            )
+            print("ERROR: Connector still exists!")
+        except Exception:
+            print("Verified: connector no longer exists")
+
+    finally:
+        if connector_id:
+            try:
+                await client.beta.connectors.delete_async(
+                    connector_id=connector_id,
+                )
+                print(f"Cleanup: deleted {connector_id}")
+            except Exception:
+                pass
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  let connectorId: string | undefined;
+
+  try {
+    // 1. Create
+    const connector = await client.beta.connectors.create({
+      name: "lifecycle_test",
+      description: "Ephemeral connector for testing",
+      server: "https://mcp.deepwiki.com/mcp",
+      visibility: "private",
+    });
+    connectorId = connector.id;
+    console.log(`Created: ${connector.name} (${connector.id})`);
+
+    // 2. Get — verify it exists
+    const fetched = await client.beta.connectors.get({
+      connectorIdOrName: "lifecycle_test",
+    });
+    console.log(`Fetched: ${fetched.name} — ${fetched.description}`);
+
+    // 3. List — find it in the list
+    const page = await client.beta.connectors.list({ pageSize: 50 });
+    const names = (page.items ?? []).map((c) => c.name);
+    console.assert(names.includes("lifecycle_test"));
+    console.log(`Listed: found among ${(page.items ?? []).length} connectors`);
+
+    // 4. Update — change description
+    const updated = await client.beta.connectors.update({
+      connectorId: connectorId!,
+      connectorMCPUpdate: {
+        description: "Updated description for lifecycle test",
+      },
+    });
+    console.log(`Updated: ${updated.description}`);
+
+    // 5. Delete
+    const result = await client.beta.connectors.delete({
+      connectorId: connectorId!,
+    });
+    console.log(`Deleted: ${result.message}`);
+    connectorId = undefined;
+
+    // 6. Verify deletion
+    try {
+      await client.beta.connectors.get({
+        connectorIdOrName: "lifecycle_test",
+      });
+      console.log("ERROR: Connector still exists!");
+    } catch {
+      console.log("Verified: connector no longer exists");
+    }
+  } finally {
+    if (connectorId) {
+      try {
+        await client.beta.connectors.delete({ connectorId });
+        console.log(`Cleanup: deleted ${connectorId}`);
+      } catch {
+        // already deleted
+      }
+    }
+  }
+}
+
+main();
+```
+
+**Output:**
+
+```
+Created: lifecycle_test (c3d4e5f6-...)
+Fetched: lifecycle_test — Ephemeral connector for testing
+Listed: found among 15 connectors
+Updated: Updated description for lifecycle test
+Deleted: Connector deleted successfully
+Verified: connector no longer exists
+```

--- a/mistral/connectors/02-connectors-in-conversations-and-agents.md
+++ b/mistral/connectors/02-connectors-in-conversations-and-agents.md
@@ -1,0 +1,1165 @@
+# Using Connectors in Conversations Cookbook
+
+Use MCP connectors, built-in tools, and agents in Mistral AI conversations.
+
+> **API status:** Conversations use `client.beta.conversations`. Agents use `client.beta.agents`. These are **beta** endpoints and may change.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Reading Conversation Responses](#reading-conversation-responses)
+- [Recipes](#recipes)
+  - [1. Hello World — First Conversation](#1-hello-world--first-conversation)
+  - [2. Conversation with Web Search](#2-conversation-with-web-search)
+  - [3. Conversation with a Custom Connector](#3-conversation-with-a-custom-connector)
+  - [4. Combining Multiple Tools in One Conversation](#4-combining-multiple-tools-in-one-conversation)
+  - [5. Filtering Connector Tools — Include / Exclude](#5-filtering-connector-tools--include--exclude)
+  - [6. Creating an Agent with Connectors](#6-creating-an-agent-with-connectors)
+  - [7. OAuth-Authenticated Connectors (Gmail)](#7-oauth-authenticated-connectors-gmail)
+  - [8. Full Example — Create a Connector, Chat, and Clean Up](#8-full-example--create-a-connector-chat-and-clean-up)
+- [Python / TypeScript Naming Conventions](#python--typescript-naming-conventions)
+- [Troubleshooting](#troubleshooting)
+- [Error Codes Reference](#error-codes-reference)
+
+---
+
+## Prerequisites
+
+### Install
+
+```bash
+# Python
+pip install mistralai
+# or with uv
+uv add mistralai
+```
+
+```bash
+# TypeScript
+pnpm add @mistralai/mistralai
+```
+
+### Required environment variables
+
+```bash
+MISTRAL_API_KEY=your-mistral-api-key
+```
+
+Get your API key from the [Mistral AI dashboard](https://console.mistral.ai/).
+
+### What you need before starting
+
+Most recipes assume you already have:
+- A working `client` (see [Recipe 1](#1-hello-world--first-conversation))
+- An existing connector for the custom-connector recipes — see the [Connectors Management Cookbook](./connectors-management.md) to create one
+
+---
+
+## Reading Conversation Responses
+
+Every recipe in this cookbook uses a small `display_response` helper to print the model's text output. The Conversations API returns a list of `outputs`; each output with `type == "message.output"` holds the model's reply. Content can be a plain string or a list of content chunks.
+
+**Python:**
+
+```python
+def display_response(response) -> None:
+    for output in response.outputs:
+        if output.type == "message.output":
+            content = output.content
+            if isinstance(content, str):
+                print(content)
+            else:
+                text = "".join(
+                    chunk.text if hasattr(chunk, "text") else str(chunk)
+                    for chunk in content
+                )
+                print(text)
+```
+
+**TypeScript:**
+
+```typescript
+function displayResponse(response: any): void {
+  for (const output of response.outputs ?? []) {
+    if (output.type === "message.output") {
+      const content = output.content;
+      if (typeof content === "string") {
+        console.log(content);
+      } else if (Array.isArray(content)) {
+        const text = content
+          .map((chunk: any) => chunk.text ?? String(chunk))
+          .join("");
+        console.log(text);
+      }
+    }
+  }
+}
+```
+
+All recipes below reference this helper. Copy it into your project, or inline the logic.
+
+---
+
+## Recipes
+
+---
+
+### 1. Hello World — First Conversation
+
+**Goal:** Send your first message and read the response — no tools, no connectors.
+
+**When to use:**
+- Verifying your setup works end-to-end.
+- Getting familiar with the response structure before adding connectors.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    response = await client.beta.conversations.start_async(
+        model="mistral-small-latest",
+        inputs=[
+            {"role": "user", "content": "What is the capital of France?"}
+        ],
+    )
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const response = await client.beta.conversations.start({
+    model: "mistral-small-latest",
+    inputs: [
+      { role: "user", content: "What is the capital of France?" },
+    ],
+  });
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/conversations" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "inputs": [{"role": "user", "content": "What is the capital of France?"}]
+  }'
+```
+
+**Example of output:**
+
+```
+The capital of France is Paris.
+```
+
+**How it works:**
+- `conversations.start` / `start_async` sends a stateless conversation turn to the model.
+- The response contains a list of `outputs`. Each with `type == "message.output"` holds the model's reply.
+- No tools or connectors are required for a basic conversation.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | Bad API key | Check `MISTRAL_API_KEY` |
+| `422 Unprocessable Entity` | Invalid model name | Use a valid model like `mistral-small-latest` |
+
+---
+
+### 2. Conversation with Web Search
+
+**Goal:** Give the model access to real-time web information — no custom connector needed.
+
+**When to use:**
+- The user's question requires up-to-date information (weather, news, current events).
+- Quick integration without creating or managing connectors.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    response = await client.beta.conversations.start_async(
+        model="mistral-small-latest",
+        inputs=[
+            {
+                "role": "user",
+                "content": "What is the current weather in Paris? Use web search.",
+            }
+        ],
+        tools=[
+            {"type": "web_search"},
+        ],
+    )
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const response = await client.beta.conversations.start({
+    model: "mistral-small-latest",
+    inputs: [
+      {
+        role: "user",
+        content: "What is the current weather in Paris? Use web search.",
+      },
+    ],
+    tools: [
+      { type: "web_search" },
+    ],
+  });
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/conversations" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "inputs": [{"role": "user", "content": "What is the current weather in Paris?"}],
+    "tools": [{"type": "web_search"}]
+  }'
+```
+
+**Example of output:**
+
+```
+Based on current web search results, the weather in Paris today is 8°C with partly cloudy skies...
+```
+
+**How it works:**
+- `web_search` is a built-in tool type — no connector creation required.
+- The model autonomously decides whether to invoke the search based on the query.
+- Search results are incorporated into the model's response automatically.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `422 Unprocessable Entity` | Invalid tool type | Ensure the type is exactly `"web_search"` |
+
+---
+
+### 3. Conversation with a Custom Connector
+
+**Goal:** Use a custom MCP connector in a conversation so the model can call external tools.
+
+**When to use:**
+- You've registered a connector (e.g., DeepWiki) and want the model to use its tools.
+- Connecting domain-specific capabilities to the model (code search, documentation lookup, actions, etc.).
+
+**Prereqs:**
+- An existing connector — see the [Connectors Management Cookbook](./connectors-management.md) to create one.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    response = await client.beta.conversations.start_async(
+        model="mistral-small-latest",
+        inputs=[
+            {
+                "role": "user",
+                "content": "Using deepwiki, tell me about the structure of the sqlite/sqlite repository.",
+            }
+        ],
+        tools=[
+            {
+                "type": "connector",
+                "connector_id": "my_deepwiki",  # name or UUID
+            },
+        ],
+    )
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const response = await client.beta.conversations.start({
+    model: "mistral-small-latest",
+    inputs: [
+      {
+        role: "user",
+        content:
+          "Using deepwiki, tell me about the structure of the sqlite/sqlite repository.",
+      },
+    ],
+    tools: [
+      {
+        type: "connector",
+        connectorId: "my_deepwiki", // name or UUID
+      },
+    ],
+  });
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/conversations" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "inputs": [{"role": "user", "content": "Using deepwiki, tell me about the structure of the sqlite/sqlite repository."}],
+    "tools": [{"type": "connector", "connector_id": "my_deepwiki"}]
+  }'
+```
+
+**Example of output:**
+
+```
+The sqlite/sqlite repository is organized into several key directories:
+- src/ — core SQLite source code
+- ext/ — extensions
+- test/ — test suite
+...
+```
+
+**How it works:**
+- The `connector_id` field accepts the connector's **name** or **UUID**.
+- The model discovers the tools exposed by the MCP server and decides which to call.
+- Tool calls and results are handled server-side — you only see the final response.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `404 Not Found` (or graceful fallback) | Connector name/ID doesn't exist — the API may return a 404 or handle gracefully | Verify with `client.beta.connectors.get` |
+| `422 Unprocessable Entity` | Connector is inactive or MCP server unreachable | Check the MCP server URL |
+
+---
+
+### 4. Combining Multiple Tools in One Conversation
+
+**Goal:** Give the model access to web search **and** custom connectors simultaneously.
+
+**When to use:**
+- You want the model to choose the best tool for the job from several options.
+- Building a multi-capability assistant (e.g., search the web + query internal docs).
+
+**Prereqs:**
+- An existing connector.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    response = await client.beta.conversations.start_async(
+        model="mistral-small-latest",
+        inputs=[
+            {
+                "role": "user",
+                "content": "What tools do you have access to? List them briefly.",
+            }
+        ],
+        tools=[
+            {"type": "web_search"},
+            {
+                "type": "connector",
+                "connector_id": "my_deepwiki",
+            },
+        ],
+    )
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const response = await client.beta.conversations.start({
+    model: "mistral-small-latest",
+    inputs: [
+      {
+        role: "user",
+        content: "What tools do you have access to? List them briefly.",
+      },
+    ],
+    tools: [
+      { type: "web_search" },
+      {
+        type: "connector",
+        connectorId: "my_deepwiki",
+      },
+    ],
+  });
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/conversations" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "inputs": [{"role": "user", "content": "What tools do you have access to? List them briefly."}],
+    "tools": [
+      {"type": "web_search"},
+      {"type": "connector", "connector_id": "my_deepwiki"}
+    ]
+  }'
+```
+
+**Example of output:**
+
+```
+I have access to the following tools:
+1. Web Search — search the internet for real-time information
+2. read_wiki_structure — explore repository wiki structure
+3. read_wiki_contents — read specific wiki pages
+4. ask_question — ask questions about a repository
+```
+
+**How it works:**
+- The `tools` array accepts any mix of built-in tools (`web_search`) and custom connectors.
+- Each connector exposes its own set of MCP tools; the model sees all of them.
+- The model decides which tool(s) to invoke based on the user's question.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `422 Unprocessable Entity` | Duplicate connector IDs in the tools array | Each connector should appear only once |
+
+---
+
+### 5. Filtering Connector Tools — Include / Exclude
+
+**Goal:** Control which MCP tools from a connector are visible to the model.
+
+**When to use:**
+- A connector exposes many tools but you only need a subset.
+- You want to prevent the model from calling a specific tool (e.g., a write/delete operation).
+- Reducing tool noise to improve model accuracy.
+
+**Prereqs:**
+- An existing connector and knowledge of the tool names it exposes.
+
+> **Note:** Use **either** `include` or `exclude`, not both simultaneously.
+
+#### Excluding specific tools
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    response = await client.beta.conversations.start_async(
+        model="mistral-small-latest",
+        inputs=[
+            {
+                "role": "user",
+                "content": "What tools do you have access to? List their names.",
+            }
+        ],
+        tools=[
+            {
+                "type": "connector",
+                "connector_id": "my_deepwiki",
+                "tool_configuration": {
+                    "exclude": ["read_wiki_structure"],
+                },
+            },
+        ],
+    )
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const response = await client.beta.conversations.start({
+    model: "mistral-small-latest",
+    inputs: [
+      {
+        role: "user",
+        content: "What tools do you have access to? List their names.",
+      },
+    ],
+    tools: [
+      {
+        type: "connector",
+        connectorId: "my_deepwiki",
+        toolConfiguration: {
+          exclude: ["read_wiki_structure"],
+        },
+      },
+    ],
+  });
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/conversations" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "inputs": [{"role": "user", "content": "What tools do you have access to?"}],
+    "tools": [{
+      "type": "connector",
+      "connector_id": "my_deepwiki",
+      "tool_configuration": { "exclude": ["read_wiki_structure"] }
+    }]
+  }'
+```
+
+**Output:**
+
+```
+I have access to: read_wiki_contents, ask_question
+```
+
+#### Including only specific tools
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    response = await client.beta.conversations.start_async(
+        model="mistral-small-latest",
+        inputs=[
+            {
+                "role": "user",
+                "content": "What tools do you have access to? List their names.",
+            }
+        ],
+        tools=[
+            {
+                "type": "connector",
+                "connector_id": "my_deepwiki",
+                "tool_configuration": {
+                    "include": ["ask_question"],
+                },
+            },
+        ],
+    )
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const response = await client.beta.conversations.start({
+    model: "mistral-small-latest",
+    inputs: [
+      {
+        role: "user",
+        content: "What tools do you have access to? List their names.",
+      },
+    ],
+    tools: [
+      {
+        type: "connector",
+        connectorId: "my_deepwiki",
+        toolConfiguration: {
+          include: ["ask_question"],
+        },
+      },
+    ],
+  });
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/conversations" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "inputs": [{"role": "user", "content": "What tools do you have access to?"}],
+    "tools": [{
+      "type": "connector",
+      "connector_id": "my_deepwiki",
+      "tool_configuration": { "include": ["ask_question"] }
+    }]
+  }'
+```
+
+**Example of output:**
+
+```
+I have access to: ask_question
+```
+
+**How it works:**
+- `tool_configuration.exclude` removes listed tools from the connector. All others remain available.
+- `tool_configuration.include` allowlists listed tools. All others are hidden.
+- Tool names must match exactly what the MCP server exposes. Ask the model to list its tools first (without any filter) to discover the exact names.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `422 Unprocessable Entity` | Tool name doesn't match any tool on the MCP server | List all tools first to get exact names |
+| `400 Bad Request` | Both `include` and `exclude` provided | Use only one at a time |
+
+---
+
+### 6. Creating an Agent with Connectors
+
+**Goal:** Create a persistent agent pre-configured with connectors and custom instructions, then chat with it.
+
+**When to use:**
+- You want a reusable agent that always has access to specific tools — no need to pass the `tools` array on every call.
+- Building a product feature where users interact with a specialized assistant.
+
+**Prereqs:**
+- An existing connector.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    agent_id: str | None = None
+    try:
+        # 1. Create the agent
+        agent = await client.beta.agents.create_async(
+            name="deepwiki_agent",
+            description="Agent with DeepWiki access for code repository exploration",
+            model="mistral-small-latest",
+            instructions="You are a helpful assistant that can explore code repositories using DeepWiki. Be concise.",
+            tools=[
+                {
+                    "type": "connector",
+                    "connector_id": "my_deepwiki",
+                },
+            ],
+        )
+        agent_id = agent.id
+        print(f"Created agent: {agent.name} ({agent.id})")
+
+        # 2. Start a conversation using the agent
+        response = await client.beta.conversations.start_async(
+            agent_id=agent.id,
+            inputs=[
+                {
+                    "role": "user",
+                    "content": "What is the main purpose of the sqlite repository?",
+                }
+            ],
+        )
+        display_response(response)
+
+    finally:
+        # 3. Cleanup
+        if agent_id:
+            await client.beta.agents.delete_async(agent_id=agent_id)
+            print(f"Deleted agent: {agent_id}")
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  let agentId: string | undefined;
+  try {
+    // 1. Create the agent
+    const agent = await client.beta.agents.create({
+      name: "deepwiki_agent",
+      description: "Agent with DeepWiki access for code repository exploration",
+      model: "mistral-small-latest",
+      instructions:
+        "You are a helpful assistant that can explore code repositories using DeepWiki. Be concise.",
+      tools: [
+        {
+          type: "connector",
+          connectorId: "my_deepwiki",
+        },
+      ],
+    });
+    agentId = agent.id;
+    console.log(`Created agent: ${agent.name} (${agent.id})`);
+
+    // 2. Start a conversation using the agent
+    const response = await client.beta.conversations.start({
+      agentId: agent.id,
+      inputs: [
+        {
+          role: "user",
+          content: "What is the main purpose of the sqlite repository?",
+        },
+      ],
+    });
+    displayResponse(response);
+  } finally {
+    // 3. Cleanup
+    if (agentId) {
+      await client.beta.agents.delete({ agentId });
+      console.log(`Deleted agent: ${agentId}`);
+    }
+  }
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+# Create agent
+curl -X POST "https://api.mistral.ai/v1/agents" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "deepwiki_agent",
+    "description": "Agent with DeepWiki access",
+    "model": "mistral-small-latest",
+    "instructions": "You are a helpful assistant that can explore code repositories using DeepWiki. Be concise.",
+    "tools": [{"type": "connector", "connector_id": "my_deepwiki"}]
+  }'
+
+# Start conversation with agent (use the agent ID from the response above)
+curl -X POST "https://api.mistral.ai/v1/conversations" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "<agent-id>",
+    "inputs": [{"role": "user", "content": "What is the main purpose of the sqlite repository?"}]
+  }'
+
+# Delete agent when done
+curl -X DELETE "https://api.mistral.ai/v1/agents/<agent-id>" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}"
+```
+
+**Example of output:**
+
+```
+Created agent: deepwiki_agent (b2c3d4e5-6789-01ab-cdef-234567890abc)
+SQLite is a self-contained, serverless, zero-configuration SQL database engine...
+Deleted agent: b2c3d4e5-6789-01ab-cdef-234567890abc
+```
+
+**How it works:**
+- Agents are persistent configurations: **model + instructions + tools**.
+- When you start a conversation with `agent_id`, the model, instructions, and tools are pre-loaded — no need to pass them again.
+- The agent's `tools` array uses the same format as the `tools` parameter in conversations.
+- Use `agent_id` **instead of** `model` when starting a conversation — not both.
+- Delete agents with `client.beta.agents.delete` / `delete_async` when they are no longer needed.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `404 Not Found` | The connector referenced in the agent's tools doesn't exist | Create the connector first |
+| `422 Unprocessable Entity` | Both `model` and `agent_id` provided, or invalid tool format | Use only `agent_id` when chatting with an agent |
+
+---
+
+### 7. OAuth-Authenticated Connectors (Gmail)
+
+**Goal:** Use a connector that requires OAuth2 authentication, such as Gmail.
+
+**When to use:**
+- Integrating with services that require user-level OAuth tokens (Gmail, Google Drive, Slack, etc.).
+- Building features where the model accesses user-specific data.
+
+**Prereqs:**
+- A valid OAuth2 access token for the target service.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    google_oauth_token = "your-google-oauth-token"
+
+    response = await client.beta.conversations.start_async(
+        model="mistral-small-latest",
+        inputs=[
+            {
+                "role": "user",
+                "content": "What's the latest email I received?",
+            }
+        ],
+        tools=[
+            {
+                "type": "connector",
+                "connector_id": "gmail",
+                "authorization": {
+                    "type": "oauth2-token",
+                    "value": google_oauth_token,
+                },
+            },
+        ],
+    )
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const googleOauthToken = "your-google-oauth-token";
+
+  const response = await client.beta.conversations.start({
+    model: "mistral-small-latest",
+    inputs: [
+      {
+        role: "user",
+        content: "What's the latest email I received?",
+      },
+    ],
+    tools: [
+      {
+        type: "connector",
+        connectorId: "gmail",
+        authorization: {
+          type: "oauth2-token",
+          value: googleOauthToken,
+        },
+      },
+    ],
+  });
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/conversations" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "inputs": [{"role": "user", "content": "What is the latest email I received?"}],
+    "tools": [{
+      "type": "connector",
+      "connector_id": "gmail",
+      "authorization": {
+        "type": "oauth2-token",
+        "value": "<your-google-oauth-token>"
+      }
+    }]
+  }'
+```
+
+**Example of output:**
+
+```
+Your latest email is from John Doe with the subject "Q1 Report Review" received at 2:30 PM today...
+```
+
+**How it works:**
+- The `authorization` field is passed **per-tool**, not globally — different connectors can use different tokens.
+- `type: "oauth2-token"` tells the backend to forward the token to the MCP server.
+- The token is **not stored** by Mistral — it is used for the duration of the request only.
+- Built-in connectors like `gmail` are pre-registered; you don't need to create them.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | OAuth token is expired | Refresh the token and retry |
+| `403 Forbidden` | Token doesn't have required scopes | Request the correct scopes (e.g., `gmail.readonly`) |
+
+---
+
+### 8. Full Example — Create a Connector, Chat, and Clean Up
+
+**Goal:** End-to-end workflow: create a connector, use it in a conversation, then clean up.
+
+**When to use:**
+- Integration tests.
+- Ephemeral connectors for one-off tasks.
+- Template for production workflows.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    connector_id: str | None = None
+
+    try:
+        # 1. Create a connector
+        connector = await client.beta.connectors.create_async(
+            name="ephemeral_deepwiki",
+            description="Temporary connector for a one-off task",
+            server="https://mcp.deepwiki.com/mcp",
+            visibility="private",
+        )
+        connector_id = str(connector.id)
+        print(f"Created connector: {connector.name} ({connector.id})")
+
+        # 2. Use it in a simple conversation
+        response = await client.beta.conversations.start_async(
+            model="mistral-small-latest",
+            inputs=[
+                {
+                    "role": "user",
+                    "content": "Using deepwiki, summarize the sqlite/sqlite repo in one sentence.",
+                }
+            ],
+            tools=[
+                {"type": "connector", "connector_id": "ephemeral_deepwiki"},
+            ],
+        )
+        print("\nConversation response:")
+        display_response(response)
+
+        # 3. Use it alongside web search
+        response = await client.beta.conversations.start_async(
+            model="mistral-small-latest",
+            inputs=[
+                {
+                    "role": "user",
+                    "content": "Search the web for the latest SQLite release version, then use deepwiki to find where the version number is defined in the sqlite/sqlite repo.",
+                }
+            ],
+            tools=[
+                {"type": "web_search"},
+                {"type": "connector", "connector_id": "ephemeral_deepwiki"},
+            ],
+        )
+        print("\nMulti-tool response:")
+        display_response(response)
+
+    finally:
+        # 4. Always clean up
+        if connector_id:
+            result = await client.beta.connectors.delete_async(
+                connector_id=connector_id,
+            )
+            print(f"\nCleaned up connector: {result.message}")
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  let connectorId: string | undefined;
+
+  try {
+    // 1. Create a connector
+    const connector = await client.beta.connectors.create({
+      name: "ephemeral_deepwiki",
+      description: "Temporary connector for a one-off task",
+      server: "https://mcp.deepwiki.com/mcp",
+      visibility: "private",
+    });
+    connectorId = connector.id;
+    console.log(`Created connector: ${connector.name} (${connector.id})`);
+
+    // 2. Use it in a simple conversation
+    const response = await client.beta.conversations.start({
+      model: "mistral-small-latest",
+      inputs: [
+        {
+          role: "user",
+          content:
+            "Using deepwiki, summarize the sqlite/sqlite repo in one sentence.",
+        },
+      ],
+      tools: [
+        { type: "connector", connectorId: "ephemeral_deepwiki" },
+      ],
+    });
+    console.log("\nConversation response:");
+    displayResponse(response);
+
+    // 3. Use it alongside web search
+    const multiResponse = await client.beta.conversations.start({
+      model: "mistral-small-latest",
+      inputs: [
+        {
+          role: "user",
+          content:
+            "Search the web for the latest SQLite release version, then use deepwiki to find where the version number is defined in the sqlite/sqlite repo.",
+        },
+      ],
+      tools: [
+        { type: "web_search" },
+        { type: "connector", connectorId: "ephemeral_deepwiki" },
+      ],
+    });
+    console.log("\nMulti-tool response:");
+    displayResponse(multiResponse);
+  } finally {
+    // 4. Always clean up
+    if (connectorId) {
+      const result = await client.beta.connectors.delete({ connectorId });
+      console.log(`\nCleaned up connector: ${result.message}`);
+    }
+  }
+}
+
+main();
+```
+
+**Output:**
+
+```
+Created connector: ephemeral_deepwiki (c3d4e5f6-...)
+
+Conversation response:
+SQLite is a self-contained, serverless SQL database engine used worldwide.
+
+Multi-tool response:
+The latest SQLite release is 3.45.1. The version number is defined in src/sqlite.h...
+
+Cleaned up connector: Connector deleted successfully
+```
+
+**How it works:**
+- The `try/finally` pattern ensures the connector is always deleted, even if the conversation fails.
+- This recipe combines connector CRUD (from the [Connectors Management Cookbook](./connectors-management.md)) with conversation usage.
+- The second conversation demonstrates the model intelligently routing between web search and the custom connector within a single request.

--- a/mistral/connectors/03-connectors-tool-calling.md
+++ b/mistral/connectors/03-connectors-tool-calling.md
@@ -1,0 +1,439 @@
+# Connectors Tool Calling Cookbook
+
+Call individual tools on an MCP connector directly, without going through a conversation.
+
+> **API status:** Tool calling uses `client.beta.connectors.call_tool`. This is a **beta** endpoint and may change.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [When to Use Direct Tool Calling](#when-to-use-direct-tool-calling)
+- [Recipes](#recipes)
+  - [1. Initialize the Client](#1-initialize-the-client)
+  - [2. Create a Connector](#2-create-a-connector)
+  - [3. Call a Tool on a Connector](#3-call-a-tool-on-a-connector)
+  - [4. Full Example — Create, Call a Tool, and Clean Up](#4-full-example--create-call-a-tool-and-clean-up)
+- [Python / TypeScript Naming Conventions](#python--typescript-naming-conventions)
+- [Troubleshooting](#troubleshooting)
+- [Error Codes Reference](#error-codes-reference)
+
+---
+
+## Prerequisites
+
+### Install
+
+```bash
+# Python
+pip install mistralai
+# or with uv
+uv add mistralai
+```
+
+```bash
+# TypeScript
+pnpm add @mistralai/mistralai
+```
+
+### Required environment variables
+
+Create a `.env` file at your project root:
+
+```bash
+MISTRAL_API_KEY=your-mistral-api-key
+```
+
+Get your API key from the [Mistral AI dashboard](https://console.mistral.ai/).
+
+### What you need before starting
+
+- A working `client` (see [Recipe 1](#1-initialize-the-client))
+- An existing connector — see the [Connectors Management Cookbook](./01-connectors-management.md) to create one
+
+---
+
+## When to Use Direct Tool Calling
+
+Direct tool calling (`call_tool`) lets you invoke a single MCP tool on a connector without starting a conversation. This is useful when:
+
+- **You already know which tool to call** — no need for the model to decide.
+- **You want raw tool output** — e.g., fetching structured data for downstream processing.
+- **Building pipelines** — chaining tool calls programmatically rather than relying on the model's orchestration.
+- **Debugging** — verifying that a connector's tools work correctly before using them in conversations.
+
+For scenarios where the model should autonomously pick which tools to call, use the [Conversations API](./02-connectors-in-conversations-and-agents.md) instead.
+
+---
+
+## Recipes
+
+---
+
+### 1. Initialize the Client
+
+**Prereqs:** `MISTRAL_API_KEY` set in your environment or `.env` file.
+
+**Python:**
+
+```python
+import os
+from mistralai import Mistral
+
+client = Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: process.env.MISTRAL_API_KEY });
+```
+
+**curl:**
+
+```bash
+# All subsequent curl examples assume these variables are set:
+export MISTRAL_API_KEY="your-api-key"
+export BASE_URL="https://api.mistral.ai"
+```
+
+**Output:** None — the client is ready to use.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | Invalid API key | Regenerate your key on the Mistral dashboard |
+
+---
+
+### 2. Create a Connector
+
+**Goal:** Register a connector so its tools can be called directly.
+
+**When to use:**
+- First step before calling tools — you need a connector to target.
+- If you already have a connector, skip to [Recipe 3](#3-call-a-tool-on-a-connector).
+
+**Prereqs:** An initialized `client` ([Recipe 1](#1-initialize-the-client)).
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    connector = await client.beta.connectors.create_async(
+        name="my_deepwiki",
+        description="DeepWiki MCP connector for code repository exploration",
+        server="https://mcp.deepwiki.com/mcp",
+        visibility="private",
+    )
+    print(f"ID:   {connector.id}")
+    print(f"Name: {connector.name}")
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const connector = await client.beta.connectors.create({
+    name: "my_deepwiki",
+    description: "DeepWiki MCP connector for code repository exploration",
+    server: "https://mcp.deepwiki.com/mcp",
+    visibility: "private",
+  });
+  console.log(`ID:   ${connector.id}`);
+  console.log(`Name: ${connector.name}`);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "${BASE_URL}/v1/connectors" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my_deepwiki",
+    "description": "DeepWiki MCP connector for code repository exploration",
+    "server": "https://mcp.deepwiki.com/mcp",
+    "visibility": "private"
+  }'
+```
+
+**Output:**
+
+```
+ID:   a1b2c3d4-5678-90ab-cdef-1234567890ab
+Name: my_deepwiki
+```
+
+**How it works:**
+- See the [Connectors Management Cookbook](./01-connectors-management.md) for full details on creating, updating, and deleting connectors.
+- The connector must be created before you can call its tools.
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `409 Conflict` | A connector with this name already exists | Choose a different name or delete the existing one first |
+
+---
+
+### 3. Call a Tool on a Connector
+
+**Goal:** Invoke a specific tool exposed by an MCP connector and get the raw result.
+
+**When to use:**
+- You know exactly which tool to call and what arguments to pass.
+- You want the raw tool output without model interpretation.
+- Building automated pipelines that chain tool calls.
+- Debugging or verifying that a connector's tools respond correctly.
+
+**Prereqs:**
+- An existing connector — by name or ID.
+- Knowledge of the tool name and its expected arguments. You can discover available tools by asking the model to list them in a [conversation](./02-connectors-in-conversations-and-agents.md#4-combining-multiple-tools-in-one-conversation), or by checking the connector's `tools` field via `client.beta.connectors.get`.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    result = await client.beta.connectors.call_tool_async(
+        connector_id_or_name="my_deepwiki",
+        tool_name="read_wiki_structure",
+        arguments={"repoName": "sqlite/sqlite"},
+    )
+    print(f"Tool output:\n{result.content}")
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const result = await client.beta.connectors.callTool({
+    connectorIdOrName: "my_deepwiki",
+    toolName: "read_wiki_structure",
+    arguments: { repoName: "sqlite/sqlite" },
+  });
+  console.log(`Tool output:\n${result.content}`);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "${BASE_URL}/v1/connectors/my_deepwiki/call_tool" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool_name": "read_wiki_structure",
+    "arguments": {"repoName": "sqlite/sqlite"}
+  }'
+```
+
+**Example of output:**
+
+```
+Tool output:
+# sqlite/sqlite Wiki Structure
+
+- Overview
+  - Architecture
+  - Build System
+  - SQL Language
+- Core Components
+  - Parser
+  - Code Generator
+  - Virtual Machine
+  ...
+```
+
+**How it works:**
+- `call_tool` / `call_tool_async` sends a direct request to the MCP server through the connector, bypassing the conversation model entirely.
+- `connector_id_or_name` accepts either the connector's **name** or **UUID**.
+- `tool_name` must match exactly one of the tools the MCP server exposes.
+- `arguments` is a dictionary/object of key-value pairs expected by the tool.
+- The response contains a `content` field with the raw output from the MCP server.
+
+### 4. Full Example — Create, Call a Tool, and Clean Up
+
+**Goal:** End-to-end workflow: create a connector, call one of its tools directly, then clean up.
+
+**When to use:**
+- Integration tests for tool calling.
+- Ephemeral connectors for one-off data fetching.
+- Template for programmatic tool-calling pipelines.
+
+**Python:**
+
+```python
+import asyncio
+from mistralai import Mistral
+
+client = Mistral(api_key="your-api-key")
+
+
+async def main() -> None:
+    connector_id: str | None = None
+
+    try:
+        # 1. Create a connector
+        connector = await client.beta.connectors.create_async(
+            name="toolcall_deepwiki",
+            description="Temporary connector for direct tool calling",
+            server="https://mcp.deepwiki.com/mcp",
+            visibility="private",
+        )
+        connector_id = str(connector.id)
+        print(f"Created connector: {connector.name} ({connector.id})")
+
+        # 2. Call a tool directly
+        result = await client.beta.connectors.call_tool_async(
+            connector_id_or_name=str(connector.id),
+            tool_name="read_wiki_structure",
+            arguments={"repoName": "sqlite/sqlite"},
+        )
+        print(f"\nTool 'read_wiki_structure' output:\n{result.content[:500]}")
+
+        # 3. Call another tool
+        result = await client.beta.connectors.call_tool_async(
+            connector_id_or_name=str(connector.id),
+            tool_name="ask_question",
+            arguments={
+                "repoName": "sqlite/sqlite",
+                "question": "What is the purpose of the VDBE?",
+            },
+        )
+        print(f"\nTool 'ask_question' output:\n{result.content[:500]}")
+
+    finally:
+        # 4. Always clean up
+        if connector_id:
+            result = await client.beta.connectors.delete_async(
+                connector_id=connector_id,
+            )
+            print(f"\nCleaned up connector: {result.message}")
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import Mistral from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  let connectorId: string | undefined;
+
+  try {
+    // 1. Create a connector
+    const connector = await client.beta.connectors.create({
+      name: "toolcall_deepwiki",
+      description: "Temporary connector for direct tool calling",
+      server: "https://mcp.deepwiki.com/mcp",
+      visibility: "private",
+    });
+    connectorId = connector.id;
+    console.log(`Created connector: ${connector.name} (${connector.id})`);
+
+    // 2. Call a tool directly
+    let result = await client.beta.connectors.callTool({
+      connectorIdOrName: connector.id,
+      toolName: "read_wiki_structure",
+      arguments: { repoName: "sqlite/sqlite" },
+    });
+    console.log(`\nTool 'read_wiki_structure' output:\n${result.content?.substring(0, 500)}`);
+
+    // 3. Call another tool
+    result = await client.beta.connectors.callTool({
+      connectorIdOrName: connector.id,
+      toolName: "ask_question",
+      arguments: {
+        repoName: "sqlite/sqlite",
+        question: "What is the purpose of the VDBE?",
+      },
+    });
+    console.log(`\nTool 'ask_question' output:\n${result.content?.substring(0, 500)}`);
+  } finally {
+    // 4. Always clean up
+    if (connectorId) {
+      const deleteResult = await client.beta.connectors.delete({ connectorId });
+      console.log(`\nCleaned up connector: ${deleteResult.message}`);
+    }
+  }
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+# 1. Create a connector
+curl -X POST "${BASE_URL}/v1/connectors" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "toolcall_deepwiki",
+    "description": "Temporary connector for direct tool calling",
+    "server": "https://mcp.deepwiki.com/mcp",
+    "visibility": "private"
+  }'
+
+# 2. Call a tool (use the connector name or ID)
+curl -X POST "${BASE_URL}/v1/connectors/toolcall_deepwiki/call_tool" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool_name": "read_wiki_structure",
+    "arguments": {"repoName": "sqlite/sqlite"}
+  }'
+
+# 3. Call another tool
+curl -X POST "${BASE_URL}/v1/connectors/toolcall_deepwiki/call_tool" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool_name": "ask_question",
+    "arguments": {"repoName": "sqlite/sqlite", "question": "What is the purpose of the VDBE?"}
+  }'
+
+# 4. Clean up (use the connector UUID from the create response)
+curl -X DELETE "${BASE_URL}/v1/connectors/${CONNECTOR_ID}" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}"
+```

--- a/mistral/connectors/04-human-in-the-loop-confirmation.md
+++ b/mistral/connectors/04-human-in-the-loop-confirmation.md
@@ -1,0 +1,846 @@
+# Human-in-the-Loop Tool Confirmation Cookbook
+
+Add approval flows to tool calls so users can review and confirm or reject actions before they execute.
+
+> **API status:** This cookbook uses the Python SDK's `extra` module (`RunContext`, `DeferredToolCallsException`). These are **beta** features and may change.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Concepts](#concepts)
+- [Recipes](#recipes)
+  - [1. Raw API with curl](#1-raw-api-with-curl)
+  - [2. Local Functions with Confirmation](#2-local-functions-with-confirmation)
+  - [3. Connector (Gmail) with Confirmation](#3-connector-gmail-with-confirmation)
+  - [4. Server-Side Confirmation (Web Search)](#4-server-side-confirmation-web-search)
+  - [5. Mixed Tools — MCP + Local Functions + Built-in Tools](#5-mixed-tools--mcp--local-functions--built-in-tools)
+  - [6. Streaming with Confirmation](#6-streaming-with-confirmation)
+  - [7. Stateless / API-Friendly — Serialize and Resume](#7-stateless--api-friendly--serialize-and-resume)
+
+---
+
+## Prerequisites
+
+### Install
+
+`mistralai-private` is hosted on [Gemfury](https://gemfury.com/). Make sure the Gemfury index is configured before installing.
+
+```bash
+uv add 'mistralai-private>=1.14.2'
+```
+
+For [Recipe 5 (MCP mixed tools)](#5-mixed-tools--mcp--local-functions--built-in-tools), you also need the `agents` extra:
+
+```bash
+uv add 'mistralai-private[agents]>=1.14.2'
+```
+
+### Required environment variables
+
+```bash
+MISTRAL_API_KEY=your-mistral-api-key
+```
+
+Get your API key from the [Mistral AI dashboard](https://console.mistral.ai/).
+
+---
+
+## Concepts
+
+There are two kinds of deferral flows with the `RunContext.run_async` loop:
+- Client-side: local functions registered through the run context `register_func` or local MCPs through `register_mcp_client`
+- Server-side: remote connectors (gmail, web-search, ...)
+
+The `run_async` loop is responsible for interrupting itself when encountering a deferred tool call, deferred tool calls can be manifested both by local functions
+or by server-side events (through FunctionCallEntry with `confirmation_status: "pending"`).
+
+### Configuration
+
+To configure the behavior we use the same flow as for connectors with the `requires_confirmation` list.
+
+```
+tools=[
+      {
+          "type": "connector",
+          "connector_id": "gmail",
+          "tool_configuration": {
+              "include": ["gmail_search"],
+              "exclude": ["gmail_send"],           # mutually exclusive with include
+              "requires_confirmation": ["gmail_search"],
+          },
+      },
+      {
+          "type": "web_search_premium",
+          "tool_configuration": {
+              "requires_confirmation": ["web_search", "news_search"],
+          },
+      },
+  ]
+```
+
+
+---
+
+## Recipes
+
+---
+
+### 1. Raw API with curl
+
+**Goal:** The Conversations API should return `FunctionCallEntry` with `confirmation_status: "pending"` for tools that require confirmation, and accept `tool_confirmations` with `"allow"` or `"deny"` to resume.
+
+#### Connector example (Gmail)
+> Get your GMail token by enabling a Gmail connector in a session on [Le Chat](https://chat.mistral.ai) and then clicking on the 🐞 icon and searching for string `oauth` to retrieve your token.
+
+**Step 1 — Start a conversation with `requires_confirmation` and extract the IDs:**
+
+```bash
+RESPONSE=$(curl -s -X POST "https://api.mistral.ai/v1/conversations" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-medium-latest",
+    "stream": false,
+    "inputs": "whats the title of the last email i received?",
+    "tools": [
+      {
+        "type": "connector",
+        "connector_id": "gmail",
+        "authorization": {
+          "type": "oauth2-token",
+          "value": "'${GMAIL_OAUTH_TOKEN}'"
+        },
+        "tool_configuration": {
+          "requires_confirmation": ["gmail_search"]
+        }
+      }
+    ]
+  }')
+
+echo "$RESPONSE" | jq .
+
+# Extract IDs for the next step
+CONVERSATION_ID=$(echo "$RESPONSE" | jq -r '.conversation_id')
+TOOL_CALL_ID=$(echo "$RESPONSE" | jq -r '.outputs[0].tool_call_id')
+```
+
+**Expected response — early return with a pending `function.call`:**
+
+```json
+{
+    "object": "conversation.response",
+    "conversation_id": "conv_abc123...",
+    "outputs": [
+        {
+            "object": "entry",
+            "type": "function.call",
+            "created_at": "2026-02-19T13:08:53.099130Z",
+            "completed_at": null,
+            "id": "fc_019c760482eb706191b8e7396e39d540",
+            "tool_call_id": "WJfo42Ow3",
+            "name": "gmail_search",
+            "arguments": "{\"limit\": 1}",
+            "confirmation_status": "pending"
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 561,
+        "completion_tokens": 11,
+        "total_tokens": 572
+    }
+}
+```
+
+**Step 2a — Approve the tool call:**
+Use the values from Step 1.
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/conversations/${CONVERSATION_ID}" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool_confirmations": [
+      {
+        "tool_call_id": "'${TOOL_CALL_ID}'",
+        "confirmation": "allow"
+      }
+    ]
+  }'
+```
+
+**Expected response — the server executes the tool and the model answers:**
+
+```json
+{
+    "object": "conversation.response",
+    "conversation_id": "conv_abc123...",
+    "outputs": [
+        {
+            "object": "entry",
+            "type": "message.output",
+            "created_at": "2026-02-19T13:18:37.951771Z",
+            "completed_at": "2026-02-19T13:18:38.668420Z",
+            "id": "msg_019c760d6f7f77ff9bd7b1186226483e",
+            "model": "mistral-medium-latest",
+            "role": "assistant",
+            "content": "Your last email is a marketing email from Cursor, feel free to ask!"
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 610,
+        "completion_tokens": 44,
+        "total_tokens": 654
+    }
+}
+```
+
+**Step 2b — Or deny instead:**
+Use the values from Step 1.
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/conversations/${CONVERSATION_ID}" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool_confirmations": [
+      {
+        "tool_call_id": "'${TOOL_CALL_ID}'",
+        "confirmation": "deny"
+      }
+    ]
+  }'
+```
+
+**Expected response — the model handles the rejection gracefully:**
+
+```json
+{
+    "object": "conversation.response",
+    "conversation_id": "conv_abc123...",
+    "outputs": [
+        {
+            "object": "entry",
+            "type": "message.output",
+            "created_at": "2026-02-19T13:21:19.675520Z",
+            "completed_at": "2026-02-19T13:21:20.283129Z",
+            "id": "msg_019c760fe73b7794913721d4866b3623",
+            "model": "mistral-medium-latest",
+            "role": "assistant",
+            "content": "Sorry, but I couldn't retrieve the information as the tool call was denied. If you have any other questions or need assistance with something else, feel free to ask!"
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 597,
+        "completion_tokens": 35,
+        "total_tokens": 632
+    }
+}
+```
+
+#### Built-in tools example (Web Search)
+
+Multiple tools can require confirmation in a single response:
+
+```bash
+RESPONSE=$(curl -s -X POST "https://api.mistral.ai/v1/conversations" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-medium-latest",
+    "stream": false,
+    "inputs": "what are the most recent AI news? use both web_search & news_search tools",
+    "tools": [
+      {
+        "type": "web_search_premium",
+        "tool_configuration": {
+          "requires_confirmation": ["web_search", "news_search"]
+        }
+      }
+    ]
+  }')
+
+echo "$RESPONSE" | jq .
+
+# Extract IDs for the next step
+CONVERSATION_ID=$(echo "$RESPONSE" | jq -r '.conversation_id')
+TOOL_CALL_ID_1=$(echo "$RESPONSE" | jq -r '.outputs[0].tool_call_id')
+TOOL_CALL_ID_2=$(echo "$RESPONSE" | jq -r '.outputs[1].tool_call_id')
+```
+
+**Expected response — both tool calls returned as pending:**
+
+```json
+{
+    "object": "conversation.response",
+    "conversation_id": "conv_abc123...",
+    "outputs": [
+        {
+            "object": "entry",
+            "type": "function.call",
+            "id": "fc_019c763128da74b5959a9a4f6a689edb",
+            "tool_call_id": "khQCtUy16",
+            "name": "web_search",
+            "arguments": "{\"query\": \"recent AI news\"}",
+            "confirmation_status": "pending"
+        },
+        {
+            "object": "entry",
+            "type": "function.call",
+            "id": "fc_019c7631294670ecb5d124bbd5048ce7",
+            "tool_call_id": "KKt6VP6ew",
+            "name": "news_search",
+            "arguments": "{\"query\": \"AI news\", \"start_date\": \"2026-02-12\", \"end_date\": \"2026-02-19\"}",
+            "confirmation_status": "pending"
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 385,
+        "completion_tokens": 57,
+        "total_tokens": 442
+    }
+}
+```
+
+**Resume — confirm both (or deny selectively):**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/conversations/${CONVERSATION_ID}" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tool_confirmations": [
+      { "tool_call_id": "'${TOOL_CALL_ID_1}'", "confirmation": "allow" },
+      { "tool_call_id": "'${TOOL_CALL_ID_2}'", "confirmation": "allow" }
+    ]
+  }'
+```
+
+---
+
+### 2. Local Functions with Confirmation
+
+**Goal:** `run_async` should auto-execute tools with `requires_confirmation=False`, raise `DeferredToolCallsException` for tools with `requires_confirmation=True`, and resume after calling `dc.confirm()` or `dc.reject()`.
+
+```python
+import asyncio
+import os
+import random
+
+from mistralai_private import MistralPrivate
+from mistralai_private.extra.run.context import RunContext
+from mistralai_private.extra.exceptions import DeferredToolCallsException
+
+MODEL = "mistral-large-latest"
+
+
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    temp = random.randint(10, 30)
+    conditions = random.choice(["sunny", "cloudy", "partly cloudy"])
+    return f"The weather in {city} is {conditions}, {temp}C"
+
+
+def book_flight(destination: str, date: str) -> str:
+    """Book a flight to a destination."""
+    return f"Flight booked to {destination} on {date}. Confirmation: FL-{random.randint(10000, 99999)}"
+
+
+def request_approval(dc) -> bool:
+    print(f"\n[APPROVAL REQUIRED] {dc.tool_name}")
+    print(f"  Arguments: {dc.arguments}")
+    return input("  Approve? (y/n): ").strip().lower() == "y"
+
+
+async def main():
+    client = MistralPrivate(api_key=os.environ["MISTRAL_API_KEY"])
+
+    conversation_id = None
+    pending_inputs = [
+        {"role": "user", "content": "I need a vacation somewhere warm next Friday. Can you help?"}
+    ]
+
+    while True:
+        async with RunContext(model=MODEL) as run_ctx:
+            run_ctx.conversation_id = conversation_id
+            run_ctx.register_func(get_weather, requires_confirmation=False)
+            run_ctx.register_func(book_flight, requires_confirmation=True)
+
+            try:
+                result = await client.beta.conversations.run_async(
+                    run_ctx=run_ctx,
+                    inputs=pending_inputs,
+                    instructions="You are a travel assistant. Available destinations are: Guingamp, Aurillac, Brive-la-Gaillarde, Rodez, and Millau. Check the weather and book a flight to the warmest one. Do not ask for confirmation, just book it.",
+                )
+
+                print(f"\nFinal response: {result.output_entries}")
+                break
+
+            except DeferredToolCallsException as deferred:
+                conversation_id = deferred.conversation_id
+
+                pending_inputs = [
+                    dc.confirm() if request_approval(dc) else dc.reject("Denied by user")
+                    for dc in deferred.deferred_calls
+                ]
+
+
+asyncio.run(main())
+```
+
+Expected flow:
+
+```
+> get_weather("Guingamp") → auto-executed
+> get_weather("Aurillac") → auto-executed
+> book_flight("Aurillac", "2025-03-21") → APPROVAL REQUIRED
+  Approve? (y/n): y
+> Final response: Flight booked to Aurillac on 2025-03-21. Confirmation: FL-42857
+```
+
+---
+
+### 3. Connector (Gmail) with Confirmation
+
+**Goal:** `run_async` should raise `DeferredToolCallsException` when the server returns a `FunctionCallEntry` with `confirmation_status: "pending"` for a connector tool listed in `requires_confirmation`. Resuming with `dc.confirm()` should send `tool_confirmations` back to the server.
+
+Requires a valid Google OAuth2 token (`GMAIL_OAUTH_TOKEN` env var).
+
+```python
+import asyncio
+import os
+
+from mistralai_private import MistralPrivate
+from mistralai_private.extra.exceptions import DeferredToolCallsException
+from mistralai_private.extra.run.context import RunContext
+
+MODEL = "mistral-large-latest"
+
+
+def request_approval(dc) -> bool:
+    print(f"\n[APPROVAL REQUIRED] {dc.tool_name}")
+    print(f"  Arguments: {dc.arguments}")
+    return input("  Approve? (y/n): ").strip().lower() == "y"
+
+
+async def main():
+    client = MistralPrivate(api_key=os.environ["MISTRAL_API_KEY"])
+
+    conversation_id = None
+    pending_inputs = [
+        {"role": "user", "content": "Summarize my latest emails from Gmail."}
+    ]
+
+    while True:
+        async with RunContext(model=MODEL) as run_ctx:
+            run_ctx.conversation_id = conversation_id
+
+            try:
+                result = await client.beta.conversations.run_async(
+                    run_ctx=run_ctx,
+                    inputs=pending_inputs,
+                    instructions="You are a helpful assistant. Use the Gmail connector to access the user's emails.",
+                    tools=[
+                        {
+                            "type": "connector",
+                            "connector_id": "gmail",
+                            "authorization": {
+                                "type": "oauth2-token",
+                                "value": os.environ["GMAIL_OAUTH_TOKEN"],
+                            },
+                            "tool_configuration": {
+                                "requires_confirmation": ["gmail_search"],
+                            },
+                        },
+                    ],
+                )
+
+                for entry in result.output_entries:
+                    if hasattr(entry, "content"):
+                        print(f"\n[{entry.type}] {entry.content}")
+                    else:
+                        print(f"\n[{entry.type}] {entry.name}({entry.arguments})")
+                break
+
+            except DeferredToolCallsException as deferred:
+                conversation_id = deferred.conversation_id
+
+                pending_inputs = [
+                    dc.confirm() if request_approval(dc) else dc.reject("Denied by user")
+                    for dc in deferred.deferred_calls
+                ]
+
+
+asyncio.run(main())
+```
+
+---
+
+### 4. Server-Side Confirmation (Web Search)
+
+**Goal:** `run_async` should detect server-side deferred tool calls (`confirmation_status: "pending"`) and raise `DeferredToolCallsException` with `reason=DeferralReason.SERVER_SIDE_CONFIRMATION_REQUIRED`. Already-executed results should be available via `deferred.executed_results`.
+
+```python
+import asyncio
+import os
+
+from mistralai_private import MistralPrivate
+from mistralai_private.extra.run.context import RunContext
+from mistralai_private.extra.exceptions import DeferredToolCallsException, DeferralReason
+
+MODEL = "mistral-medium-latest"
+
+
+def request_approval(dc) -> bool:
+    print(f"\n[APPROVAL REQUIRED] {dc.tool_name}")
+    print(f"  Arguments: {dc.arguments}")
+    print(f"  Reason: {dc.reason.value}")
+    return input("  Approve? (y/n): ").strip().lower() == "y"
+
+
+async def main():
+    client = MistralPrivate(api_key=os.environ["MISTRAL_API_KEY"])
+
+    conversation_id = None
+    pending_inputs = "Search the web for the latest news about artificial intelligence today."
+
+    while True:
+        async with RunContext(model=MODEL) as run_ctx:
+            if conversation_id:
+                run_ctx.conversation_id = conversation_id
+
+            try:
+                run_result = await client.beta.conversations.run_async(
+                    run_ctx=run_ctx,
+                    inputs=pending_inputs,
+                    instructions="You are a helpful assistant. Use web search to find information.",
+                    tools=[{
+                        "type": "web_search_premium",
+                        "tool_configuration": {
+                            "requires_confirmation": ["web_search", "news_search"],
+                        },
+                    }],
+                )
+
+                print("\nFinal Response:")
+                print(run_result.output_as_text)
+                break
+
+            except DeferredToolCallsException as deferred:
+                conversation_id = deferred.conversation_id
+                print(f"\n{len(deferred.deferred_calls)} tool(s) need approval:")
+
+                for dc in deferred.deferred_calls:
+                    is_server_side = dc.reason == DeferralReason.SERVER_SIDE_CONFIRMATION_REQUIRED
+                    print(f"  - {dc.tool_name} (server_side={is_server_side})")
+
+                confirmations = [
+                    dc.confirm() if request_approval(dc) else dc.reject("Denied by user")
+                    for dc in deferred.deferred_calls
+                ]
+                pending_inputs = deferred.executed_results + confirmations
+
+
+asyncio.run(main())
+```
+
+---
+
+### 5. Mixed Tools — MCP + Local Functions + Built-in Tools
+
+**Goal:** `run_async` should handle three tool sources (remote MCP, local functions, built-in tools) in a single conversation. Each source should respect its own confirmation settings independently. `deferred.executed_results` should contain results from tools that auto-executed before the deferral.
+
+Requires `pip install mistralai-private[agents]` and a running MCP SSE server (this example uses CoinGecko).
+
+```python
+import asyncio
+import os
+
+from mistralai_private import MistralPrivate
+from mistralai_private.extra.run.context import RunContext
+from mistralai_private.extra.mcp.sse import MCPClientSSE, SSEServerParams
+from mistralai_private.extra.exceptions import DeferredToolCallsException
+
+MODEL = "mistral-medium-latest"
+
+USER_PORTFOLIO = {
+    "bitcoin": 0.5,
+    "ethereum": 2.0,
+    "solana": 10.0,
+}
+
+
+def get_portfolio() -> dict:
+    """Get the user's cryptocurrency portfolio holdings.
+
+    Returns:
+        dict: A dictionary mapping coin names to amounts held
+    """
+    return USER_PORTFOLIO
+
+
+def execute_trade(coin: str, action: str, amount: float) -> str:
+    """Execute a buy or sell trade for a cryptocurrency.
+
+    Args:
+        coin: The cryptocurrency to trade (e.g., 'bitcoin', 'ethereum')
+        action: Either 'buy' or 'sell'
+        amount: The amount to trade
+
+    Returns:
+        str: Confirmation message of the trade
+    """
+    return f"Trade executed: {action} {amount} {coin}"
+
+
+def request_approval(dc) -> bool:
+    print(f"\n[APPROVAL REQUIRED] {dc.tool_name}")
+    print(f"  Arguments: {dc.arguments}")
+    return input("  Approve? (y/n): ").strip().lower() == "y"
+
+
+async def main():
+    client = MistralPrivate(api_key=os.environ["MISTRAL_API_KEY"])
+
+    coingecko_url = "https://mcp.api.coingecko.com/sse"
+    mcp_client = MCPClientSSE(sse_params=SSEServerParams(url=coingecko_url, timeout=60))
+
+    conversation_id = None
+    pending_inputs = (
+        "I want a full analysis of my crypto portfolio. "
+        "First, get my current holdings using get_portfolio. "
+        "Then use get_coins_markets from CoinGecko to get market data for Bitcoin, Ethereum and Solana. "
+        "Search the web for any recent news about Bitcoin. "
+        "Finally, if Bitcoin's price is under $100k, buy 0.1 more using execute_trade."
+    )
+
+    while True:
+        async with RunContext(model=MODEL) as run_ctx:
+            if conversation_id:
+                run_ctx.conversation_id = conversation_id
+
+            await run_ctx.register_mcp_client(mcp_client=mcp_client)
+            run_ctx.register_func(get_portfolio, requires_confirmation=False)
+            run_ctx.register_func(execute_trade, requires_confirmation=True)
+
+            try:
+                run_result = await client.beta.conversations.run_async(
+                    run_ctx=run_ctx,
+                    inputs=pending_inputs,
+                    instructions=(
+                        "You are a crypto portfolio assistant. "
+                        "You have access to: get_portfolio (local holdings), "
+                        "CoinGecko tools (get_coins_markets for market data), "
+                        "web_search_premium (for news), and execute_trade (for transactions)."
+                    ),
+                    tools=[{"type": "web_search_premium"}],
+                )
+
+                print("\nFinal Response:")
+                print(run_result.output_as_text)
+                break
+
+            except DeferredToolCallsException as deferred:
+                conversation_id = deferred.conversation_id
+                print(f"\n{len(deferred.deferred_calls)} tool(s) need approval:")
+
+                confirmations = [
+                    dc.confirm() if request_approval(dc) else dc.reject("Denied by user")
+                    for dc in deferred.deferred_calls
+                ]
+                pending_inputs = deferred.executed_results + confirmations
+
+
+asyncio.run(main())
+```
+
+Expected flow:
+
+```
+> get_portfolio() → auto-executed
+> get_coins_markets(...) → auto-executed (MCP)
+> web_search("bitcoin news") → auto-executed
+> execute_trade("bitcoin", "buy", 0.1) → APPROVAL REQUIRED
+  Approve? (y/n): y
+> Final Response: Your portfolio analysis...
+```
+
+---
+
+### 6. Streaming with Confirmation
+
+**Goal:** `run_stream_async` should yield streaming events, then raise `DeferredToolCallsException` mid-stream when a deferred tool call is encountered. Resuming should work the same as `run_async`.
+
+```python
+import asyncio
+import os
+import random
+
+from mistralai_private import MistralPrivate
+from mistralai_private.extra.run.context import RunContext
+from mistralai_private.extra.run.result import RunResult
+from mistralai_private.extra.exceptions import DeferredToolCallsException
+
+MODEL = "mistral-large-latest"
+
+
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    temp = random.randint(10, 30)
+    conditions = random.choice(["sunny", "cloudy", "partly cloudy"])
+    return f"The weather in {city} is {conditions}, {temp}C"
+
+
+def book_flight(destination: str, date: str) -> str:
+    """Book a flight to a destination."""
+    return f"Flight booked to {destination} on {date}. Confirmation: FL-{random.randint(10000, 99999)}"
+
+
+def request_approval(dc) -> bool:
+    print(f"\n[APPROVAL REQUIRED] {dc.tool_name}")
+    print(f"  Arguments: {dc.arguments}")
+    return input("  Approve? (y/n): ").strip().lower() == "y"
+
+
+async def main():
+    client = MistralPrivate(api_key=os.environ["MISTRAL_API_KEY"])
+
+    conversation_id = None
+    pending_inputs = [
+        {"role": "user", "content": "I need a vacation somewhere warm next Friday. Can you help?"}
+    ]
+
+    while True:
+        async with RunContext(model=MODEL) as run_ctx:
+            run_ctx.conversation_id = conversation_id
+            run_ctx.register_func(get_weather, requires_confirmation=False)
+            run_ctx.register_func(book_flight, requires_confirmation=True)
+
+            try:
+                events = await client.beta.conversations.run_stream_async(
+                    run_ctx=run_ctx,
+                    inputs=pending_inputs,
+                    instructions="You are a travel assistant. Available destinations are: Guingamp, Aurillac, Brive-la-Gaillarde, Rodez, and Millau. Check the weather and book a flight to the warmest one. Do not ask for confirmation, just book it.",
+                )
+
+                async for event in events:
+                    if isinstance(event, RunResult):
+                        print(f"\nFinal response: {event.output_entries}")
+                        return
+                    else:
+                        print(f"Event: {event}")
+
+            except DeferredToolCallsException as deferred:
+                conversation_id = deferred.conversation_id
+
+                pending_inputs = [
+                    dc.confirm() if request_approval(dc) else dc.reject("Denied by user")
+                    for dc in deferred.deferred_calls
+                ]
+
+
+asyncio.run(main())
+```
+
+---
+
+### 7. Stateless / API-Friendly — Serialize and Resume
+
+**Goal:** `DeferredToolCallsException.to_dict()` should produce a JSON-serializable dict, and `from_dict()` should reconstruct the full state so the conversation can resume from a different process/context.
+
+Split into two scripts to simulate a real API boundary (e.g., backend returns deferred state to frontend, frontend sends back approvals).
+
+#### Script 1: Start the conversation, catch the deferral, serialize it
+
+```python
+import asyncio
+import json
+import os
+
+from mistralai_private import MistralPrivate
+from mistralai_private.extra.run.context import RunContext
+from mistralai_private.extra.exceptions import DeferredToolCallsException
+
+
+def book_flight(destination: str, date: str) -> str:
+    """Book a flight to a destination."""
+    return f"Flight booked to {destination} on {date}"
+
+
+async def main():
+    client = MistralPrivate(api_key=os.environ["MISTRAL_API_KEY"])
+
+    async with RunContext(model="mistral-large-latest") as run_ctx:
+        run_ctx.register_func(book_flight, requires_confirmation=True)
+
+        try:
+            result = await client.beta.conversations.run_async(
+                run_ctx=run_ctx,
+                inputs=[{"role": "user", "content": "Book me a flight to Paris next Friday."}],
+                instructions="You are a travel assistant. Book the flight directly.",
+            )
+            print("No confirmation needed:", result.output_as_text)
+
+        except DeferredToolCallsException as deferred:
+            state = deferred.to_dict()
+            serialized = json.dumps(state)
+
+            print("Deferred state (send this to your frontend / store it):")
+            print(serialized)
+
+
+asyncio.run(main())
+```
+
+#### Script 2: Receive approvals, deserialize, and resume
+
+```python
+import asyncio
+import json
+import os
+
+from mistralai_private import MistralPrivate
+from mistralai_private.extra.run.context import RunContext
+from mistralai_private.extra.exceptions import DeferredToolCallsException, DeferredToolCallEntry
+
+
+def book_flight(destination: str, date: str) -> str:
+    """Book a flight to a destination."""
+    return f"Flight booked to {destination} on {date}"
+
+
+async def main():
+    # In a real app: receive this from the frontend / load from DB
+    serialized = os.environ["DEFERRED_STATE"]  # the JSON string from Script 1
+    state = json.loads(serialized)
+
+    # Reconstruct the exception from the serialized state
+    deferred = DeferredToolCallsException.from_dict(state)
+
+    # Build confirmations (in a real app, the frontend tells you which to approve/reject)
+    pending_inputs = []
+    for dc in deferred.deferred_calls:
+        print(f"Tool: {dc.tool_name}, Args: {dc.arguments}")
+        pending_inputs.append(dc.confirm())
+
+    # Include any already-executed results
+    pending_inputs = list(deferred.executed_results) + pending_inputs
+
+    # Resume the conversation
+    client = MistralPrivate(api_key=os.environ["MISTRAL_API_KEY"])
+
+    async with RunContext(model="mistral-large-latest") as run_ctx:
+        run_ctx.conversation_id = deferred.conversation_id
+        run_ctx.register_func(book_flight, requires_confirmation=True)
+
+        result = await client.beta.conversations.run_async(
+            run_ctx=run_ctx,
+            inputs=pending_inputs,
+            instructions="You are a travel assistant. Book the flight directly.",
+        )
+        print("Final response:", result.output_as_text)
+
+
+asyncio.run(main())
+```

--- a/mistral/connectors/05-connectors-in-completions.md
+++ b/mistral/connectors/05-connectors-in-completions.md
@@ -1,0 +1,1252 @@
+# Using Connectors in Chat Completions Cookbook
+
+Use MCP connectors, built-in tools, and agents with the Chat Completions API (`/v1/chat/completions`) and Agent Completions API (`/v1/agents/completions`).
+
+> **SDK support:** The `mistralai_private` SDK supports connector-style tools in `chat.complete()`. Note that responses use `messages` (array) instead of `message` (object) when tools are invoked.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Conversations vs Completions — When to Use Which](#conversations-vs-completions--when-to-use-which)
+- [Reading Completion Responses](#reading-completion-responses)
+- [Recipes](#recipes)
+  - [1. Hello World — Basic Chat Completion](#1-hello-world--basic-chat-completion)
+  - [2. Completion with Image Generation](#2-completion-with-image-generation)
+  - [3. Completion with a Custom Connector](#3-completion-with-a-custom-connector)
+  - [4. Combining Multiple Tools](#4-combining-multiple-tools)
+  - [5. Creating an Agent with Connectors](#5-creating-an-agent-with-connectors)
+  - [6. Agent Completions](#6-agent-completions)
+  - [7. OAuth-Authenticated Connectors (Gmail)](#7-oauth-authenticated-connectors-gmail)
+  - [8. Full Example — Create, Complete, and Clean Up](#8-full-example--create-complete-and-clean-up)
+- [Python / TypeScript Naming Conventions](#python--typescript-naming-conventions)
+- [Troubleshooting](#troubleshooting)
+- [Error Codes Reference](#error-codes-reference)
+
+---
+
+## Prerequisites
+
+### Install
+
+```bash
+# Python - using the private SDK
+pip install mistralai-private
+# or with uv
+uv add mistralai-private
+```
+
+```bash
+# TypeScript / Node.js
+npm install @mistralai/mistralai
+```
+
+### Required environment variables
+
+```bash
+MISTRAL_API_KEY=your-mistral-api-key
+```
+
+Get your API key from the [Mistral AI dashboard](https://console.mistral.ai/).
+
+### What you need before starting
+
+Most recipes assume:
+- A valid `MISTRAL_API_KEY`
+- An existing connector for custom-connector recipes — see the [Connectors Management Cookbook](./01-connectors-management.md) to create one
+
+---
+
+## Conversations vs Completions — When to Use Which
+
+Mistral offers two APIs for interacting with models:
+
+| Feature | Conversations API | Chat Completions API |
+|---------|-------------------|---------------------|
+| Endpoint | `/v1/conversations` | `/v1/chat/completions` |
+| SDK support | `client.beta.conversations` | `client.chat.complete()` |
+| Response format | `outputs[]` with `type: "message.output"` | `choices[]` with `messages` (array) when tools are used |
+| Multi-turn state | Stateless (send full history each call) | Stateless (send full history each call) |
+| Tool execution | Server-side (automatic) | Server-side with `multi_completion` format |
+| Best for | New integrations, agent workflows | OpenAI-compatible apps, existing chat implementations |
+
+**Use Chat Completions when:**
+- You're migrating from OpenAI and want a familiar response format
+- Your existing code uses the `choices[].message` structure
+- You need compatibility with OpenAI-style SDKs
+
+**Use Conversations when:**
+- You're building new integrations from scratch
+- You want the recommended, newest API surface
+- You're using the SDK's beta features
+
+---
+
+## Reading Completion Responses
+
+Chat completions with tools return responses in a `multi_completion` format where each choice contains a `messages` array instead of a single `message`. The helper below handles both formats.
+
+**Python (SDK):**
+
+```python
+def display_response(response) -> None:
+    """Display text content from SDK chat completion response.
+
+    When using connector tools, responses use `messages` array instead of `message`.
+    """
+    for choice in response.choices:
+        # Handle multi_completion format (messages array) - used with connector tools
+        if hasattr(choice, 'messages') and choice.messages:
+            for message in choice.messages:
+                content = message.content
+                if content:
+                    if isinstance(content, str):
+                        print(content[:500] if len(content) > 500 else content)
+                    elif isinstance(content, list):
+                        for chunk in content:
+                            if hasattr(chunk, 'type'):
+                                if chunk.type == "text":
+                                    print(getattr(chunk, 'text', ''))
+                                elif chunk.type == "image_url":
+                                    print(f"[Image: {getattr(chunk, 'image_url', '')[:80]}...]")
+                tool_calls = getattr(message, 'tool_calls', None)
+                if tool_calls:
+                    print(f"Tool calls: {len(tool_calls)}")
+                    for tc in tool_calls:
+                        func = tc.function
+                        print(f"  - {func.name}: {func.arguments}")
+        # Handle standard completion format (single message)
+        elif hasattr(choice, 'message') and choice.message:
+            message = choice.message
+            content = message.content
+            if content:
+                print(content[:500] if len(content) > 500 else content)
+            tool_calls = getattr(message, 'tool_calls', None)
+            if tool_calls:
+                print(f"Tool calls: {len(tool_calls)}")
+                for tc in tool_calls:
+                    func = tc.function
+                    print(f"  - {func.name}: {func.arguments}")
+```
+
+**TypeScript:**
+
+```typescript
+function displayResponse(data: any): void {
+  for (const choice of data.choices ?? []) {
+    // Handle multi_completion format (messages array)
+    const messages = choice.messages ?? [];
+    if (messages.length > 0) {
+      for (const message of messages) {
+        const content = message.content;
+        if (content) {
+          if (typeof content === "string") {
+            console.log(content.length > 500 ? content.slice(0, 500) : content);
+          } else if (Array.isArray(content)) {
+            for (const chunk of content) {
+              if (chunk.type === "text") {
+                console.log(chunk.text ?? "");
+              } else if (chunk.type === "image_url") {
+                console.log(`[Image: ${(chunk.image_url ?? "").slice(0, 80)}...]`);
+              }
+            }
+          }
+        }
+        const toolCalls = message.tool_calls ?? [];
+        if (toolCalls.length > 0) {
+          console.log(`Tool calls: ${toolCalls.length}`);
+          for (const tc of toolCalls) {
+            const func = tc.function ?? {};
+            console.log(`  - ${func.name}: ${func.arguments}`);
+          }
+        }
+      }
+    // Handle standard completion format (single message)
+    } else {
+      const message = choice.message ?? {};
+      const content = message.content;
+      if (content) {
+        console.log(typeof content === "string" && content.length > 500 ? content.slice(0, 500) : content);
+      }
+      const toolCalls = message.tool_calls ?? [];
+      if (toolCalls.length > 0) {
+        console.log(`Tool calls: ${toolCalls.length}`);
+        for (const tc of toolCalls) {
+          const func = tc.function ?? {};
+          console.log(`  - ${func.name}: ${func.arguments}`);
+        }
+      }
+    }
+  }
+}
+```
+
+All recipes below reference this helper. Copy it into your project, or inline the logic.
+
+---
+
+## Recipes
+
+---
+
+### 1. Hello World — Basic Chat Completion
+
+**Goal:** Send your first chat completion request — no tools, no connectors.
+
+**When to use:**
+- Verifying your SDK setup works end-to-end
+- Getting familiar with the response structure before adding connectors
+
+**Python:**
+
+```python
+import asyncio
+from mistralai_private import MistralPrivate
+
+API_KEY = "your-api-key"
+
+
+async def main() -> None:
+    client = MistralPrivate(api_key=API_KEY)
+
+    response = await client.chat.complete_async(
+        model="mistral-small-latest",
+        messages=[
+            {"role": "user", "content": "What is the capital of France?"}
+        ],
+    )
+
+    # Standard completion uses choice.message
+    print(response.choices[0].message.content)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import { Mistral } from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const response = await client.chat.complete({
+    model: "mistral-small-latest",
+    messages: [
+      { role: "user", content: "What is the capital of France?" },
+    ],
+  });
+
+  console.log(response.choices[0].message.content);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/chat/completions" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "messages": [{"role": "user", "content": "What is the capital of France?"}]
+  }'
+```
+
+**Example of output:**
+
+```
+The capital of France is Paris.
+```
+
+**How it works:**
+- `/v1/chat/completions` is the standard OpenAI-compatible chat endpoint
+- Response contains `choices[]` with each choice having a `message` object
+- No tools or connectors are required for a basic completion
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | Bad API key | Check `MISTRAL_API_KEY` |
+| `422 Unprocessable Entity` | Invalid model name | Use a valid model like `mistral-small-latest` |
+
+---
+
+### 2. Completion with Image Generation
+
+**Goal:** Use the built-in `image_generation` tool in a chat completion.
+
+**When to use:**
+- Generating images based on user prompts
+- Quick integration without custom connectors
+
+**Python:**
+
+```python
+import asyncio
+from mistralai_private import MistralPrivate
+
+API_KEY = "your-api-key"
+
+
+async def main() -> None:
+    client = MistralPrivate(api_key=API_KEY)
+
+    response = await client.chat.complete_async(
+        model="mistral-small-latest",
+        messages=[
+            {
+                "role": "user",
+                "content": "Generate an image of a sunset over the ocean.",
+            }
+        ],
+        tools=[
+            {"type": "image_generation"},
+        ],
+    )
+
+    # With tools, use choice.messages (array) instead of choice.message
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import { Mistral } from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const response = await client.chat.complete({
+    model: "mistral-small-latest",
+    messages: [
+      {
+        role: "user",
+        content: "Generate an image of a sunset over the ocean.",
+      },
+    ],
+    tools: [
+      { type: "image_generation" },
+    ],
+  });
+
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/chat/completions" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "messages": [{"role": "user", "content": "Generate an image of a sunset over the ocean."}],
+    "tools": [{"type": "image_generation"}]
+  }'
+```
+
+**Example of output:**
+
+```
+[Image: https://files.mistral.ai/generated/abc123...]
+Here's a beautiful sunset over the ocean as requested.
+```
+
+**How it works:**
+- `image_generation` is a built-in tool type — no connector creation required
+- The model decides to invoke the tool based on the user's request
+- Generated images are returned as URLs in the response content
+- When tools are invoked, responses use `choice.messages` (array) instead of `choice.message`
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `422 Unprocessable Entity` | Invalid tool type | Ensure the type is exactly `"image_generation"` |
+
+---
+
+### 3. Completion with a Custom Connector
+
+**Goal:** Use a custom MCP connector in a chat completion so the model can call external tools.
+
+**When to use:**
+- You've registered a connector (e.g., DeepWiki) and want the model to use its tools
+- Connecting domain-specific capabilities to the model in a chat completion context
+
+**Prereqs:**
+- An existing connector — see the [Connectors Management Cookbook](./01-connectors-management.md) to create one
+
+**Python:**
+
+```python
+import asyncio
+from mistralai_private import MistralPrivate
+
+API_KEY = "your-api-key"
+
+
+async def main() -> None:
+    client = MistralPrivate(api_key=API_KEY)
+
+    response = await client.chat.complete_async(
+        model="mistral-small-latest",
+        messages=[
+            {
+                "role": "user",
+                "content": "Using deepwiki, tell me about the structure of the sqlite/sqlite repository.",
+            }
+        ],
+        tools=[
+            {
+                "type": "connector",
+                "connector_id": "my_deepwiki",  # name or UUID
+            },
+        ],
+    )
+
+    # With connector tools, use choice.messages (array)
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import { Mistral } from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const response = await client.chat.complete({
+    model: "mistral-small-latest",
+    messages: [
+      {
+        role: "user",
+        content:
+          "Using deepwiki, tell me about the structure of the sqlite/sqlite repository.",
+      },
+    ],
+    tools: [
+      {
+        type: "connector",
+        connector_id: "my_deepwiki", // name or UUID
+      },
+    ],
+  });
+
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/chat/completions" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "messages": [{"role": "user", "content": "Using deepwiki, tell me about the structure of the sqlite/sqlite repository."}],
+    "tools": [{"type": "connector", "connector_id": "my_deepwiki"}]
+  }'
+```
+
+**Example of output:**
+
+```
+The sqlite/sqlite repository is organized into several key directories:
+- src/ — core SQLite source code
+- ext/ — extensions
+- test/ — test suite
+...
+```
+
+**How it works:**
+- The `connector_id` field accepts the connector's **name** or **UUID**
+- The model discovers the tools exposed by the MCP server and decides which to call
+- Tool calls and results are handled server-side — you only see the final response
+- Responses use `choice.messages` (array) when tools are invoked
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `404 Not Found` | Connector name/ID doesn't exist | Verify with connector list/get API |
+| `422 Unprocessable Entity` | Connector is inactive or MCP server unreachable | Check the MCP server URL |
+
+---
+
+### 4. Combining Multiple Tools
+
+**Goal:** Give the model access to built-in tools **and** custom connectors simultaneously in a chat completion.
+
+**When to use:**
+- You want the model to choose the best tool for the job from several options
+- Building a multi-capability assistant
+
+**Prereqs:**
+- An existing connector
+
+**Python:**
+
+```python
+import asyncio
+from mistralai_private import MistralPrivate
+
+API_KEY = "your-api-key"
+
+
+async def main() -> None:
+    client = MistralPrivate(api_key=API_KEY)
+
+    response = await client.chat.complete_async(
+        model="mistral-small-latest",
+        messages=[
+            {
+                "role": "user",
+                "content": "What tools do you have access to? List them briefly.",
+            }
+        ],
+        tools=[
+            {"type": "image_generation"},
+            {
+                "type": "connector",
+                "connector_id": "my_deepwiki",
+            },
+        ],
+    )
+
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import { Mistral } from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const response = await client.chat.complete({
+    model: "mistral-small-latest",
+    messages: [
+      {
+        role: "user",
+        content: "What tools do you have access to? List them briefly.",
+      },
+    ],
+    tools: [
+      { type: "image_generation" },
+      {
+        type: "connector",
+        connector_id: "my_deepwiki",
+      },
+    ],
+  });
+
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/chat/completions" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "messages": [{"role": "user", "content": "What tools do you have access to? List them briefly."}],
+    "tools": [
+      {"type": "image_generation"},
+      {"type": "connector", "connector_id": "my_deepwiki"}
+    ]
+  }'
+```
+
+**Example of output:**
+
+```
+I have access to the following tools:
+1. Image Generation — create images from text descriptions
+2. read_wiki_structure — explore repository wiki structure
+3. read_wiki_contents — read specific wiki pages
+4. ask_question — ask questions about a repository
+```
+
+**How it works:**
+- The `tools` array accepts any mix of built-in tools (`image_generation`) and custom connectors
+- Each connector exposes its own set of MCP tools; the model sees all of them
+- The model decides which tool(s) to invoke based on the user's question
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `422 Unprocessable Entity` | Duplicate connector IDs in the tools array | Each connector should appear only once |
+
+---
+
+### 5. Creating an Agent with Connectors
+
+**Goal:** Create a persistent agent pre-configured with connectors and custom instructions for use with the Agent Completions API.
+
+**When to use:**
+- You want a reusable agent that always has access to specific tools
+- Building a product feature where users interact with a specialized assistant
+- Simplifying API calls by pre-configuring model, instructions, and tools
+
+**Prereqs:**
+- An existing connector
+
+**Python:**
+
+```python
+import asyncio
+from mistralai_private import MistralPrivate
+
+API_KEY = "your-api-key"
+
+
+async def main() -> None:
+    client = MistralPrivate(api_key=API_KEY)
+    agent_id: str | None = None
+
+    try:
+        # Create the agent
+        agent = await client.beta.agents.create_async(
+            name="deepwiki_completion_agent",
+            description="Agent with DeepWiki access for code repository exploration",
+            model="mistral-small-latest",
+            instructions="You are a helpful assistant that can explore code repositories using DeepWiki. Be concise.",
+            tools=[
+                {
+                    "type": "connector",
+                    "connector_id": "my_deepwiki",
+                },
+            ],
+        )
+        agent_id = str(agent.id)
+        print(f"Created agent: {agent.name} ({agent_id})")
+
+    finally:
+        # Clean up
+        if agent_id:
+            await client.beta.agents.delete_async(agent_id=agent_id)
+            print(f"Deleted agent: {agent_id}")
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import { Mistral } from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  let agentId: string | undefined;
+
+  try {
+    // Create the agent
+    const agent = await client.beta.agents.create({
+      name: "deepwiki_completion_agent",
+      description: "Agent with DeepWiki access for code repository exploration",
+      model: "mistral-small-latest",
+      instructions:
+        "You are a helpful assistant that can explore code repositories using DeepWiki. Be concise.",
+      tools: [
+        {
+          type: "connector",
+          connectorId: "my_deepwiki",
+        },
+      ],
+    });
+    agentId = agent.id;
+    console.log(`Created agent: ${agent.name} (${agentId})`);
+  } finally {
+    // Clean up
+    if (agentId) {
+      await client.beta.agents.delete({ agentId });
+      console.log(`Deleted agent: ${agentId}`);
+    }
+  }
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+# Create agent
+curl -X POST "https://api.mistral.ai/v1/agents" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "deepwiki_completion_agent",
+    "description": "Agent with DeepWiki access",
+    "model": "mistral-small-latest",
+    "instructions": "You are a helpful assistant that can explore code repositories using DeepWiki. Be concise.",
+    "tools": [{"type": "connector", "connector_id": "my_deepwiki"}]
+  }'
+
+# Delete agent when done (use the agent ID from the response above)
+curl -X DELETE "https://api.mistral.ai/v1/agents/<agent-id>" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}"
+```
+
+**Example of output:**
+
+```
+Created agent: deepwiki_completion_agent (b2c3d4e5-6789-01ab-cdef-234567890abc)
+Deleted agent: b2c3d4e5-6789-01ab-cdef-234567890abc
+```
+
+**How it works:**
+- Agents are persistent configurations: **model + instructions + tools**
+- Once created, use the agent's ID with `/v1/agents/completions` to chat
+- The agent's `tools` array uses the same format as the `tools` parameter in completions
+- Delete agents when they are no longer needed
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `404 Not Found` | The connector referenced in the agent's tools doesn't exist | Create the connector first |
+| `409 Conflict` | An agent with this name already exists | Choose a different name or delete the existing agent |
+
+---
+
+### 6. Agent Completions
+
+**Goal:** Chat with a pre-configured agent using the Agent Completions API.
+
+**When to use:**
+- You have an existing agent with tools configured
+- You want to avoid passing model, instructions, and tools on every request
+- Building conversational flows with a specialized assistant
+
+**Prereqs:**
+- An existing agent ID (see [Recipe 5](#5-creating-an-agent-with-connectors))
+
+**Python:**
+
+```python
+import asyncio
+from mistralai_private import MistralPrivate
+
+API_KEY = "your-api-key"
+
+
+async def main() -> None:
+    client = MistralPrivate(api_key=API_KEY)
+    agent_id = "your-agent-id"  # From agent creation
+
+    response = await client.agents.complete_async(
+        agent_id=agent_id,
+        messages=[
+            {
+                "role": "user",
+                "content": "What is the main purpose of the sqlite repository?",
+            }
+        ],
+    )
+
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import { Mistral } from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const agentId = "your-agent-id"; // From agent creation
+
+  const response = await client.agents.complete({
+    agentId,
+    messages: [
+      {
+        role: "user",
+        content: "What is the main purpose of the sqlite repository?",
+      },
+    ],
+  });
+
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/agents/completions" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "<agent-id>",
+    "messages": [{"role": "user", "content": "What is the main purpose of the sqlite repository?"}]
+  }'
+```
+
+**Example of output:**
+
+```
+SQLite is a self-contained, serverless, zero-configuration SQL database engine. It is the most widely deployed database in the world, embedded in countless applications including web browsers, mobile phones, and operating systems.
+```
+
+**How it works:**
+- `/v1/agents/completions` uses the agent's pre-configured model, instructions, and tools
+- You only need to provide `agent_id` and `messages` — no need to repeat configuration
+- The response format is the same as `/v1/chat/completions`
+- For multi-turn conversations, include the full message history in the `messages` array
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `404 Not Found` | Invalid agent ID | The agent may have been deleted |
+| `422 Unprocessable Entity` | Missing `agent_id` or invalid message format | Ensure `agent_id` is provided |
+
+---
+
+### 7. OAuth-Authenticated Connectors (Gmail)
+
+**Goal:** Use a connector that requires OAuth2 authentication in a chat completion.
+
+**When to use:**
+- Integrating with services that require user-level OAuth tokens (Gmail, Google Drive, Slack, etc.)
+- Building features where the model accesses user-specific data
+
+**Prereqs:**
+- A valid OAuth2 access token for the target service
+
+**Python:**
+
+```python
+import asyncio
+from mistralai_private import MistralPrivate
+
+API_KEY = "your-api-key"
+
+
+async def main() -> None:
+    client = MistralPrivate(api_key=API_KEY)
+    google_oauth_token = "your-google-oauth-token"
+
+    response = await client.chat.complete_async(
+        model="mistral-small-latest",
+        messages=[
+            {
+                "role": "user",
+                "content": "What's the latest email I received?",
+            }
+        ],
+        tools=[
+            {
+                "type": "connector",
+                "connector_id": "gmail",
+                "authorization": {
+                    "type": "oauth2-token",
+                    "value": google_oauth_token,
+                },
+            },
+        ],
+    )
+
+    display_response(response)
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import { Mistral } from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  const googleOauthToken = "your-google-oauth-token";
+
+  const response = await client.chat.complete({
+    model: "mistral-small-latest",
+    messages: [
+      {
+        role: "user",
+        content: "What's the latest email I received?",
+      },
+    ],
+    tools: [
+      {
+        type: "connector",
+        connector_id: "gmail",
+        authorization: {
+          type: "oauth2-token",
+          value: googleOauthToken,
+        },
+      },
+    ],
+  });
+
+  displayResponse(response);
+}
+
+main();
+```
+
+**curl:**
+
+```bash
+curl -X POST "https://api.mistral.ai/v1/chat/completions" \
+  -H "Authorization: Bearer ${MISTRAL_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mistral-small-latest",
+    "messages": [{"role": "user", "content": "What is the latest email I received?"}],
+    "tools": [{
+      "type": "connector",
+      "connector_id": "gmail",
+      "authorization": {
+        "type": "oauth2-token",
+        "value": "<your-google-oauth-token>"
+      }
+    }]
+  }'
+```
+
+**Example of output:**
+
+```
+Your latest email is from John Doe with the subject "Q1 Report Review" received at 2:30 PM today...
+```
+
+**How it works:**
+- The `authorization` field is passed **per-tool**, not globally — different connectors can use different tokens
+- `type: "oauth2-token"` tells the backend to forward the token to the MCP server
+- The token is **not stored** by Mistral — it is used for the duration of the request only
+- Built-in connectors like `gmail` are pre-registered; you don't need to create them
+
+**Common errors & fixes:**
+
+| Error | Cause | Fix |
+|---|---|---|
+| `401 Unauthorized` | OAuth token is expired | Refresh the token and retry |
+| `403 Forbidden` | Token doesn't have required scopes | Request the correct scopes (e.g., `gmail.readonly`) |
+
+---
+
+### 8. Full Example — Create, Complete, and Clean Up
+
+**Goal:** End-to-end workflow: create a connector, use it in chat completions and with an agent, then clean up.
+
+**When to use:**
+- Integration tests
+- Ephemeral connectors for one-off tasks
+- Template for production workflows
+
+**Python:**
+
+```python
+import asyncio
+from mistralai_private import MistralPrivate
+
+API_KEY = "your-api-key"
+CONNECTOR_HEADERS = {"X-Private-Access": "your-private-access-key"}
+
+
+async def main() -> None:
+    client = MistralPrivate(api_key=API_KEY)
+    connector_id: str | None = None
+    agent_id: str | None = None
+
+    try:
+        # 1. Create a connector
+        connector = await client.beta.connectors.create_async(
+            name="completions_deepwiki",
+            description="DeepWiki connector for completion testing",
+            server="https://mcp.deepwiki.com/mcp",
+            visibility="private",
+            http_headers=CONNECTOR_HEADERS,
+        )
+        connector_id = str(connector.id)
+        print(f"Created connector: {connector.name} ({connector_id})")
+
+        # 2. Use it in a chat completion
+        response = await client.chat.complete_async(
+            model="mistral-small-latest",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Using deepwiki, summarize the sqlite/sqlite repo in one sentence.",
+                }
+            ],
+            tools=[
+                {"type": "connector", "connector_id": "completions_deepwiki"},
+            ],
+        )
+        print("\nChat completion response:")
+        display_response(response)
+
+        # 3. Create an agent with the connector
+        agent = await client.beta.agents.create_async(
+            name="completions_test_agent",
+            description="Test agent for completion cookbook",
+            model="mistral-small-latest",
+            instructions="You are a helpful assistant. Be concise.",
+            tools=[
+                {"type": "connector", "connector_id": connector_id},
+            ],
+        )
+        agent_id = str(agent.id)
+        print(f"\nCreated agent: {agent.name} ({agent_id})")
+
+        # 4. Use agent completions
+        response = await client.agents.complete_async(
+            agent_id=agent_id,
+            messages=[
+                {
+                    "role": "user",
+                    "content": "What programming language is SQLite written in?",
+                }
+            ],
+        )
+        print("\nAgent completion response:")
+        display_response(response)
+
+        print("\n" + "=" * 60)
+        print("  SUCCESS")
+        print("=" * 60)
+
+    finally:
+        # Clean up
+        print("\nCleaning up...")
+        if agent_id:
+            try:
+                await client.beta.agents.delete_async(agent_id=agent_id)
+                print(f"Deleted agent: {agent_id}")
+            except Exception:
+                pass
+
+        if connector_id:
+            try:
+                await client.beta.connectors.delete_async(
+                    connector_id=connector_id,
+                    http_headers=CONNECTOR_HEADERS,
+                )
+                print(f"Deleted connector: {connector_id}")
+            except Exception:
+                pass
+
+
+asyncio.run(main())
+```
+
+**TypeScript:**
+
+```typescript
+import { Mistral } from "@mistralai/mistralai";
+
+const client = new Mistral({ apiKey: "your-api-key" });
+
+async function main(): Promise<void> {
+  let connectorId: string | undefined;
+  let agentId: string | undefined;
+
+  try {
+    // 1. Create a connector
+    const connector = await client.beta.connectors.create({
+      name: "completions_deepwiki",
+      description: "DeepWiki connector for completion testing",
+      server: "https://mcp.deepwiki.com/mcp",
+      visibility: "private",
+    });
+    connectorId = connector.id;
+    console.log(`Created connector: ${connector.name} (${connectorId})`);
+
+    // 2. Use it in a chat completion
+    let response = await client.chat.complete({
+      model: "mistral-small-latest",
+      messages: [
+        {
+          role: "user",
+          content: "Using deepwiki, summarize the sqlite/sqlite repo in one sentence.",
+        },
+      ],
+      tools: [
+        { type: "connector", connector_id: "completions_deepwiki" },
+      ],
+    });
+    console.log("\nChat completion response:");
+    displayResponse(response);
+
+    // 3. Create an agent with the connector
+    const agent = await client.beta.agents.create({
+      name: "completions_test_agent",
+      description: "Test agent for completion cookbook",
+      model: "mistral-small-latest",
+      instructions: "You are a helpful assistant. Be concise.",
+      tools: [
+        { type: "connector", connectorId },
+      ],
+    });
+    agentId = agent.id;
+    console.log(`\nCreated agent: ${agent.name} (${agentId})`);
+
+    // 4. Use agent completions
+    response = await client.agents.complete({
+      agentId,
+      messages: [
+        {
+          role: "user",
+          content: "What programming language is SQLite written in?",
+        },
+      ],
+    });
+    console.log("\nAgent completion response:");
+    displayResponse(response);
+
+    console.log("\n" + "=".repeat(60));
+    console.log("  SUCCESS");
+    console.log("=".repeat(60));
+  } finally {
+    // Clean up
+    console.log("\nCleaning up...");
+    if (agentId) {
+      try {
+        await client.beta.agents.delete({ agentId });
+        console.log(`Deleted agent: ${agentId}`);
+      } catch {
+        // ignore
+      }
+    }
+    if (connectorId) {
+      try {
+        await client.beta.connectors.delete({ connectorId });
+        console.log(`Deleted connector: ${connectorId}`);
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+main();
+```
+
+**Output:**
+
+```
+Created connector: completions_deepwiki (c3d4e5f6-...)
+
+Chat completion response:
+SQLite is a self-contained, serverless SQL database engine used worldwide.
+
+Created agent: completions_test_agent (d4e5f6a7-...)
+
+Agent completion response:
+SQLite is primarily written in C.
+
+============================================================
+  SUCCESS
+============================================================
+
+Cleaning up...
+Deleted agent: d4e5f6a7-...
+Deleted connector: c3d4e5f6-...
+```
+
+**How it works:**
+- The `try/finally` pattern ensures resources are always cleaned up, even if requests fail
+- This recipe demonstrates the full workflow: connector creation → chat completion → agent creation → agent completion
+- Both `/v1/chat/completions` and `/v1/agents/completions` support the same tool formats
+
+---
+
+## Python / TypeScript Naming Conventions
+
+| Concept | Python SDK | TypeScript SDK |
+|---------|-----------|----------------|
+| Connector ID | `connector_id` | `connectorId` |
+| Agent ID | `agent_id` | `agentId` |
+| Tool type | `type` | `type` |
+| OAuth authorization | `authorization.type`, `authorization.value` | `authorization.type`, `authorization.value` |
+
+---
+
+## Troubleshooting
+
+### "Connector not found" error
+- Verify the connector exists by listing connectors or getting by name/ID
+- Check that the connector name/ID is spelled correctly
+- Ensure the connector was created in the same workspace
+
+### "Tool calls not appearing in response"
+- The model decides whether to call tools based on the user's message
+- Try being more explicit in your prompt (e.g., "Use deepwiki to...")
+- Ensure the tool type is valid (`connector`, `image_generation`, etc.)
+
+### "Timeout errors"
+- MCP servers may take time to respond — increase the timeout
+- Check if the MCP server URL is reachable
+- Try with a simpler query first
+
+### "OAuth token expired"
+- OAuth tokens have limited lifetimes
+- Implement token refresh logic in your application
+- Check the token's expiration before making requests
+
+### "AttributeError: 'Unset' object has no attribute 'content'"
+- When using connector tools, responses use `choice.messages` (array) instead of `choice.message`
+- Use the `display_response` helper function or check for both formats
+- Access content via `response.choices[0].messages[0].content`
+
+---
+
+## Error Codes Reference
+
+| HTTP Status | Error | Common Causes |
+|-------------|-------|---------------|
+| `400` | Bad Request | Invalid JSON, missing required fields |
+| `401` | Unauthorized | Invalid or missing API key, expired OAuth token |
+| `403` | Forbidden | Insufficient permissions, invalid OAuth scopes |
+| `404` | Not Found | Connector/agent doesn't exist, wrong ID |
+| `409` | Conflict | Resource with same name already exists |
+| `422` | Unprocessable Entity | Invalid model name, invalid tool format, unreachable MCP server |
+| `429` | Too Many Requests | Rate limit exceeded |
+| `500` | Internal Server Error | Server-side issue, retry with backoff |
+| `502` | Bad Gateway | MCP server unreachable or returned an error |
+| `504` | Gateway Timeout | MCP server took too long to respond |


### PR DESCRIPTION
## Summary

Adds 5 cookbooks for the Connectors API (beta) under `mistral/connectors/`, sourced from [mistralai/connector-sdk-demo/cookbooks](https://github.com/mistralai/connector-sdk-demo/tree/main/cookbooks):

- `01-connectors-management.md` — CRUD operations on MCP connectors
- `02-connectors-in-conversations-and-agents.md` — using connectors in chat & agents
- `03-connectors-tool-calling.md` — connectors with tool calling
- `04-human-in-the-loop-confirmation.md` — human confirmation flow
- `05-connectors-in-completions.md` — connectors in completions

## How the files were added

Files were fetched directly from `mistralai/connector-sdk-demo` via the GitHub API and decoded from base64:

\`\`\`bash
for f in 01-connectors-management.md 02-connectors-in-conversations-and-agents.md 03-connectors-tool-calling.md 04-human-in-the-loop-confirmation.md 05-connectors-in-completions.md; do
  gh api repos/mistralai/connector-sdk-demo/contents/cookbooks/$f \
    | python3 -c "import json,sys,base64; d=json.load(sys.stdin); open('mistral/connectors/$f','wb').write(base64.b64decode(d['content']))"
done
\`\`\`

> **Note:** These files are a snapshot from connector-sdk-demo at the time of this PR. If the source files are updated, this PR should be re-synced manually.

## Test plan

- [ ] All 5 cookbooks render correctly on docs.mistral.ai/cookbooks
- [ ] Links and code snippets are correct
- [ ] `cookbooks.config.json` in platform-docs updated (see mistralai/platform-docs#465)

🤖 Generated with [Claude Code](https://claude.com/claude-code)