### PR TITLE
fix: migrate v1.x to v2.x package import

### DIFF
--- a/mistral/agents/agents_api/financial_analyst/mcp_servers/stdio_report_gen_server.py
+++ b/mistral/agents/agents_api/financial_analyst/mcp_servers/stdio_report_gen_server.py
@@ -2,7 +2,7 @@ from mcp.server.fastmcp import FastMCP
 import logging
 import os
 from typing import List
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 # Configure logging to only show errors
 logging.basicConfig(level=logging.ERROR)
@@ -20,10 +20,10 @@ system_prompt = "You are a professional financial analyst. Generate a very short
 def generate_report_content(prompt: str) -> str:
     """
     Generate financial report content using MistralAI LLM based on provided data
-    
+
     Args:
         prompt (str): The prompt containing financial data and analysis requirements
-    
+
     Returns:
         str: Generated report content or error message
     """

--- a/mistral/agents/agents_api/food_diet_companion/tools/configs.py
+++ b/mistral/agents/agents_api/food_diet_companion/tools/configs.py
@@ -1,4 +1,4 @@
-from mistralai import Mistral
+from mistralai.client import Mistral
 from dotenv import load_dotenv
 
 import os

--- a/mistral/agents/agents_api/multi_agents_data_analysis/backend/analysis_agent.py
+++ b/mistral/agents/agents_api/multi_agents_data_analysis/backend/analysis_agent.py
@@ -7,10 +7,10 @@ and query execution for data analysis tasks.
 
 import os
 import sqlite3
-from typing import Tuple, List, AsyncGenerator
-from mistralai import Mistral, MessageOutputEvent
+from typing import AsyncGenerator, List, Tuple
+from mistralai.client import Mistral
+from mistralai.client.models import MessageOutputEvent
 from utils.db_manager import load_excel_to_sqlite
-
 
 DATA_ANALYSIS_PROMPT = """
 You are an advanced data analysis agent with a strong attention to detail. You are given a question and database schema in metadata. Your task is to write a SQL query to answer the question.

--- a/mistral/agents/agents_api/multi_agents_data_analysis/backend/report_agent.py
+++ b/mistral/agents/agents_api/multi_agents_data_analysis/backend/report_agent.py
@@ -10,7 +10,7 @@ import os
 import json
 from typing import Optional, Any
 from pathlib import Path
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 MODEL = "mistral-medium-latest"
 

--- a/mistral/agents/agents_api/multi_agents_data_analysis/backend/simulation_agent.py
+++ b/mistral/agents/agents_api/multi_agents_data_analysis/backend/simulation_agent.py
@@ -9,7 +9,7 @@ import os
 import json
 import pandas as pd
 import sqlite3
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 # Mock market rates
 MARKET_RATES = {

--- a/mistral/agents/agents_api/prd_linear_ticket/app.py
+++ b/mistral/agents/agents_api/prd_linear_ticket/app.py
@@ -1,6 +1,7 @@
 import os
 import chainlit as cl
-from mistralai import Mistral, MessageOutputEvent, FunctionCallEvent, ResponseErrorEvent
+from mistralai.client import Mistral
+from mistralai.client.models import MessageOutputEvent, FunctionCallEvent, ResponseErrorEvent
 from mistralai.extra.run.context import RunContext
 from mcp import StdioServerParameters
 from mistralai.extra.mcp.stdio import MCPClientSTDIO
@@ -18,23 +19,23 @@ server_to_tool_map = {
 
 class PRDLinearAgent:
     """Main agent for PRD generation and Linear ticket creation using MistralAI with MCP servers"""
-    
+
     def __init__(self):
         self.client = None
         self.agent = None
-        
+
     async def initialize(self):
         """Initialize the MistralAI client and create the PRD/Linear agent"""
         api_key = os.environ["MISTRAL_API_KEY"]
         self.client = Mistral(api_key=api_key)
-        
+
         self.agent = self.client.beta.agents.create(
             model=MODEL,
             name="prd-linear-agent",
             instructions="Generates PRD and create linear tickets.",
             description="PRD generation and Linear ticket creation agent",
         )
-    
+
     async def process_query(self, query: str):
         """Process user query using the agent with MCP servers for PRD generation and Linear ticket creation"""
         async def run_in_context():
@@ -91,10 +92,10 @@ async def main(message: cl.Message):
     """Handle incoming user messages and stream agent responses"""
     user_query = message.content.strip()
     server_tools = []
-    
+
     if not user_query:
         return
-    
+
     try:
         result_events = await prd_agent.process_query(user_query)
         msg = cl.Message(content="")
@@ -121,7 +122,7 @@ async def main(message: cl.Message):
                     case ResponseErrorEvent():
                         logger.debug(event.data)
                         await msg.stream_token(f"\n\n 🔴 Error: {event.data.message}\n\n")
-        
+
     except Exception as e:
         await cl.Message(content=f"Error: {str(e)}").send()
 

--- a/mistral/agents/agents_api/prd_linear_ticket/mcp_servers/stdio_linear_ticket_gen_server.py
+++ b/mistral/agents/agents_api/prd_linear_ticket/mcp_servers/stdio_linear_ticket_gen_server.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import os
 from typing import List, Dict, Any
 from pydantic import BaseModel
-from mistralai import Mistral
+from mistralai.client import Mistral
 from gql import gql, Client
 from gql.transport.requests import RequestsHTTPTransport
 
@@ -129,7 +129,7 @@ def create_tickets_from_prd(prd: str) -> List[Dict[str, Any]]:
     # Parse the PRD into structured feature data
     parsed_items = parse_prd(prd)
     results = []
-    
+
     # Create a Linear ticket for each feature
     for title, description in zip(
         parsed_items['Features'],

--- a/mistral/agents/agents_api/prd_linear_ticket/mcp_servers/stdio_prd_generator_server.py
+++ b/mistral/agents/agents_api/prd_linear_ticket/mcp_servers/stdio_prd_generator_server.py
@@ -1,6 +1,6 @@
 from mcp.server.fastmcp import FastMCP
 import logging
-from mistralai import Mistral
+from mistralai.client import Mistral
 import traceback
 import os
 
@@ -15,10 +15,10 @@ mistral_client = Mistral(api_key="<YOUR MISTRALAI API KEY>")
 
 def parse_transcript(file_path: str) -> str:
     """Parse a transcript PDF file and extract text from all pages using MistralAI OCR
-    
+
     Args:
         file_path (str): Path to the PDF file to process
-        
+
     Returns:
         str: Extracted text content from the PDF
     """
@@ -82,16 +82,16 @@ async def generate_prd(file_name: str) -> str:
 
         PRD:
         """
-        
+
         # Generate PRD using MistralAI
         response = mistral_client.chat.complete(
             model="mistral-medium-latest",
             messages=[{"role": "user", "content": prompt}],
             temperature=0.1
         )
-        
+
         return response.choices[0].message.content
-    
+
     except Exception as e:
         logging.error(f"Error in generate_prd: {str(e)}")
         return traceback.format_exc()

--- a/mistral/agents/non_framework/agentic_workflows/parallel_subtask_agentic_workflow.ipynb
+++ b/mistral/agents/non_framework/agentic_workflows/parallel_subtask_agentic_workflow.ipynb
@@ -116,7 +116,7 @@
         "import requests\n",
         "from typing import Any, Optional, Dict, List, Union\n",
         "from pydantic import Field, BaseModel, ValidationError\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from IPython.display import display, Markdown\n",
         "\n",
         "import nest_asyncio\n",

--- a/mistral/agents/non_framework/agentic_workflows/serial_chain_agentic_workflow.ipynb
+++ b/mistral/agents/non_framework/agentic_workflows/serial_chain_agentic_workflow.ipynb
@@ -122,7 +122,7 @@
       "outputs": [],
       "source": [
         "import os\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from typing import List, Dict, Any, Optional\n",
         "import json\n",
         "from IPython.display import display, Markdown"

--- a/mistral/agents/non_framework/earnings_calls/Multi_Agent_Earnings_Call_Analysis_System_(MAECAS).ipynb
+++ b/mistral/agents/non_framework/earnings_calls/Multi_Agent_Earnings_Call_Analysis_System_(MAECAS).ipynb
@@ -189,7 +189,7 @@
         "from abc import ABC, abstractmethod\n",
         "\n",
         "from pydantic import BaseModel, Field\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from IPython.display import display, Markdown"
       ]
     },

--- a/mistral/agents/non_framework/hubspot_dynamic_multi_agent/chainlit_app/app.py
+++ b/mistral/agents/non_framework/hubspot_dynamic_multi_agent/chainlit_app/app.py
@@ -1,7 +1,8 @@
 import chainlit as cl
 import requests
 import json
-from mistralai import Mistral, ThinkChunk, TextChunk
+from mistralai.client import Mistral
+from mistralai.client.models import ThinkChunk, TextChunk
 from typing import Dict, List
 import re
 import asyncio
@@ -41,7 +42,7 @@ class HubSpotConnector:
                     prop_list.append(prop_str)
 
                 properties[obj_type] = prop_list
-        
+
         return properties
 
     async def get_data(self, object_type: str) -> List[Dict]:
@@ -58,10 +59,10 @@ class HubSpotConnector:
 
             data = response.json()
             all_data.extend(data.get("results", []))
-            
+
             url = data.get("paging", {}).get("next", {}).get("link")
             params = {}
-        
+
         return all_data
 
     async def batch_update(self, updates: Dict) -> None:
@@ -138,7 +139,7 @@ class LeadAgent:
 
     async def analyze_query(self, query: str) -> Dict:
         """Analyze query using Magistral reasoning and create execution plan"""
-        
+
         try:
             await cl.Message(
                 content="🧠 **Lead Agent Activated**\n\n"
@@ -181,14 +182,14 @@ class LeadAgent:
 
             try:
                 analysis = await magistral_reasoning(analysis_prompt)
-                
+
                 await cl.Message(
                     content="✅ **Magistral Analysis Complete**\n\nReasoning process finished successfully!",
                     author="Lead Agent"
                 ).send()
-                
+
             except Exception as e:
-                
+
                 analysis = {
                     "reasoning": "Failed during reasoning. Using fallback plan.",
                     "conclusion": '{"sub_agents": [{"name": "priority_assigner", "task": "Assign priorities to deals based on value", "task_type": "write_back", "input_data": ["deals"], "output_format": "JSON with deal updates"}]}'
@@ -201,13 +202,13 @@ class LeadAgent:
                     execution_plan = json.loads(json_match.group(0))
                 else:
                     raise ValueError("No JSON found in analysis")
-                    
+
             except Exception as e:
                 await cl.Message(
                     content=f"⚠️ **Fallback Plan Activated**\n\nJSON parsing failed ({str(e)}), using general analysis approach",
                     author="Lead Agent"
                 ).send()
-                
+
                 execution_plan = {
                     "sub_agents": [{
                         "name": "priority_assigner",
@@ -233,13 +234,13 @@ class LeadAgent:
                 "execution_plan": execution_plan,
                 "conclusion": analysis["conclusion"]
             }
-            
+
         except Exception as e:
             await cl.Message(
                 content=f"❌ **Lead Agent Error**\n\nError: {str(e)}\n\nUsing emergency fallback...",
                 author="Lead Agent"
             ).send()
-            
+
             # Emergency fallback
             return {
                 "reasoning": f"Emergency fallback due to error: {str(e)}",
@@ -268,7 +269,7 @@ class SubAgent:
 
     async def execute(self, data: Dict, properties_context: str, hubspot_updater=None) -> Dict:
         """Execute the assigned task"""
-        
+
         await cl.Message(
             content=f"🤖 **{self.name} Activated**\n\n"
                    f"**Task Type**: {self.task_type}\n"
@@ -321,13 +322,13 @@ class SubAgent:
                 content="📤 **Preparing HubSpot Updates**\n\nValidating and formatting update payload...",
                 author=self.name
             ).send()
-            
+
             try:
                 json_match = re.search(r'\{.*\}', result, re.DOTALL)
                 if json_match:
                     updates = json.loads(json_match.group(0))
                     await hubspot_updater.batch_update(updates)
-                    
+
                     await cl.Message(
                         content="✅ **Mission Accomplished**\n\nHubSpot records updated successfully!",
                         author=self.name
@@ -354,7 +355,7 @@ class SynthesisAgent:
 
     async def synthesize(self, query: str, sub_agent_results: List[Dict], execution_plan: Dict) -> str:
         """Combine all sub-agent results into final answer"""
-        
+
         await cl.Message(
             content=f"🔄 **Synthesis Agent Activated**\n\n"
                    f"Combining insights from {len(sub_agent_results)} specialized agents...\n\n",
@@ -420,7 +421,7 @@ class AgentOrchestrator:
                    "Initializing intelligent CRM automation...\n\n"
                    "⚡ **System Components:**\n"
                    "• Lead Agent (Magistral Reasoning)\n"
-                   "• Dynamic Sub-Agents (Mistral Small)\n" 
+                   "• Dynamic Sub-Agents (Mistral Small)\n"
                    "• Synthesis Agent (Final Processing)\n"
                    "• HubSpot Connector (CRM Integration)",
             author="System Orchestrator"
@@ -428,7 +429,7 @@ class AgentOrchestrator:
 
         # Load HubSpot data and properties
         self.hubspot_properties = await self.hubspot_connector.get_properties()
-        
+
         self.hubspot_data = {
             "deals": await self.hubspot_connector.get_data("deals"),
             "contacts": await self.hubspot_connector.get_data("contacts"),
@@ -436,7 +437,7 @@ class AgentOrchestrator:
         }
 
         # Initialize lead agent with properties
-        self.lead_agent = LeadAgent(self.hubspot_properties)        
+        self.lead_agent = LeadAgent(self.hubspot_properties)
 
     async def process_query(self, query: str) -> Dict:
         """Main method to process user queries through multi-agent workflow"""
@@ -519,7 +520,7 @@ orchestrator = None
 async def start():
     """Initialize the chat session"""
     global orchestrator
-    
+
     # Check API keys
     if HUBSPOT_API_KEY == "your_hubspot_api_key_here" or MISTRAL_API_KEY == "your_mistral_api_key_here":
         await cl.Message(
@@ -538,10 +539,10 @@ async def start():
             hubspot_api_key=HUBSPOT_API_KEY,
             mistral_api_key=MISTRAL_API_KEY
         )
-        
+
         # Initialize the system
         await orchestrator.initialize()
-        
+
         # Welcome message
         await cl.Message(
             content="👋 **Welcome to HubSpot Multi-Agent Assistant!**\n\n"
@@ -551,7 +552,7 @@ async def start():
                    "Just type your question and watch the multi-agent system work!",
             author="Assistant"
         ).send()
-        
+
     except Exception as e:
         await cl.Message(
             content=f"❌ **Initialization Failed**\n\n"
@@ -564,7 +565,7 @@ async def start():
 async def main(message: cl.Message):
     """Handle incoming messages"""
     global orchestrator
-    
+
     if not orchestrator:
         await cl.Message(
             content="❌ **System Not Ready**\n\nPlease restart the application.",
@@ -575,21 +576,21 @@ async def main(message: cl.Message):
     try:
         # Process the query through multi-agent system
         result = await orchestrator.process_query(message.content)
-        
+
         # Send final answer
         await cl.Message(
             content=f"## 🎯 Final Answer\n\n{result['final_answer']}",
             author="Assistant"
         ).send()
-        
+
         # Optionally show execution summary
         summary = f"**📊 Execution Summary:**\n\n"
         summary += f"• **Active Agents**: {', '.join(result['active_agents'])}\n"
         summary += f"• **Successful Operations**: {sum(1 for r in result['sub_agent_results'] if r['result']['status'] == 'success')}\n"
         summary += f"• **Total Processing Steps**: {len(result['sub_agent_results']) + 2}\n"  # +2 for Lead and Synthesis agents
-        
+
         await cl.Message(content=summary, author="System Summary").send()
-        
+
     except Exception as e:
         await cl.Message(
             content=f"❌ **Processing Error**\n\n"

--- a/mistral/agents/non_framework/hubspot_dynamic_multi_agent/hubspot_dynamic_multi_agent_system.ipynb
+++ b/mistral/agents/non_framework/hubspot_dynamic_multi_agent/hubspot_dynamic_multi_agent_system.ipynb
@@ -165,7 +165,7 @@
       "source": [
         "import requests\n",
         "import json\n",
-        "from mistralai import Mistral, ThinkChunk, TextChunk\n",
+        "from mistralai.client import Mistral, ThinkChunk, TextChunk\n",
         "from datetime import datetime, timedelta\n",
         "from typing import Dict, List, Any, Optional\n",
         "import re\n"

--- a/mistral/agents/non_framework/industrial_knowledge_agent/IndustrialKnowledgeAgent.ipynb
+++ b/mistral/agents/non_framework/industrial_knowledge_agent/IndustrialKnowledgeAgent.ipynb
@@ -200,7 +200,7 @@
         "from typing import List, Dict, Any, Tuple\n",
         "\n",
         "# LLM and Data Processing\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from pydantic import BaseModel\n",
         "import pandas as pd\n",
         "import sqlite3\n",

--- a/mistral/agents/non_framework/recruitment_agent/Multi_Agent_Workflow_For_Recruitment.ipynb
+++ b/mistral/agents/non_framework/recruitment_agent/Multi_Agent_Workflow_For_Recruitment.ipynb
@@ -163,7 +163,7 @@
         "import requests\n",
         "from typing import List, Optional, Dict, Any\n",
         "from pydantic import BaseModel, Field\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "import smtplib\n",
         "from email.mime.text import MIMEText\n",

--- a/mistral/agents/non_framework/transcript_linearticket_agent/TranscriptToLinearTicketAgent.ipynb
+++ b/mistral/agents/non_framework/transcript_linearticket_agent/TranscriptToLinearTicketAgent.ipynb
@@ -183,7 +183,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from gql import gql, Client\n",
         "from gql.transport.requests import RequestsHTTPTransport\n",
         "from pydantic import BaseModel\n",

--- a/mistral/classifier_factory/intent_classification.ipynb
+++ b/mistral/classifier_factory/intent_classification.ipynb
@@ -405,7 +405,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "import os\n",
         "\n",
         "# Set the API key for Mistral\n",

--- a/mistral/classifier_factory/moderation_classifier.ipynb
+++ b/mistral/classifier_factory/moderation_classifier.ipynb
@@ -711,7 +711,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "import os\n",
         "\n",
         "# Set the API key for Mistral\n",

--- a/mistral/classifier_factory/product_classification.ipynb
+++ b/mistral/classifier_factory/product_classification.ipynb
@@ -403,7 +403,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "# Set the API key for Mistral\n",
         "api_key = \"API_KEY\"\n",

--- a/mistral/connectors/01-connectors-management.md
+++ b/mistral/connectors/01-connectors-management.md
@@ -63,7 +63,7 @@ Get your API key from the [Mistral AI dashboard](https://console.mistral.ai/).
 
 ```python
 import os
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key=os.environ["MISTRAL_API_KEY"])
 ```
@@ -108,7 +108,7 @@ export BASE_URL="https://api.mistral.ai"
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -212,7 +212,7 @@ Created at:  2026-02-24 10:30:00
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -311,7 +311,7 @@ Verified: get-by-name and get-by-ID return the same connector.
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -465,7 +465,7 @@ Active connectors: 12
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -569,7 +569,7 @@ New name: my_deepwiki_v2
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -666,7 +666,7 @@ Confirmed deleted: NotFoundError
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 

--- a/mistral/connectors/02-connectors-in-conversations-and-agents.md
+++ b/mistral/connectors/02-connectors-in-conversations-and-agents.md
@@ -118,7 +118,7 @@ All recipes below reference this helper. Copy it into your project, or inline th
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -200,7 +200,7 @@ The capital of France is Paris.
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -297,7 +297,7 @@ Based on current web search results, the weather in Paris today is 8°C with par
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -406,7 +406,7 @@ The sqlite/sqlite repository is organized into several key directories:
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -523,7 +523,7 @@ I have access to the following tools:
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -614,7 +614,7 @@ I have access to: read_wiki_contents, ask_question
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -728,7 +728,7 @@ I have access to: ask_question
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -892,7 +892,7 @@ Deleted agent: b2c3d4e5-6789-01ab-cdef-234567890abc
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -1014,7 +1014,7 @@ Your latest email is from John Doe with the subject "Q1 Report Review" received 
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 

--- a/mistral/connectors/03-connectors-tool-calling.md
+++ b/mistral/connectors/03-connectors-tool-calling.md
@@ -79,7 +79,7 @@ For scenarios where the model should autonomously pick which tools to call, use 
 
 ```python
 import os
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key=os.environ["MISTRAL_API_KEY"])
 ```
@@ -124,7 +124,7 @@ export BASE_URL="https://api.mistral.ai"
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -215,7 +215,7 @@ Name: my_deepwiki
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 
@@ -300,7 +300,7 @@ Tool output:
 
 ```python
 import asyncio
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 client = Mistral(api_key="your-api-key")
 

--- a/mistral/connectors/04-human-in-the-loop-confirmation.md
+++ b/mistral/connectors/04-human-in-the-loop-confirmation.md
@@ -97,7 +97,7 @@ import asyncio
 import os
 import random
 
-from mistralai import Mistral
+from mistralai.client import Mistral
 from mistralai.extra.run.context import RunContext
 from mistralai.extra.exceptions import DeferredToolCallsException
 
@@ -177,7 +177,7 @@ asyncio.run(main())
 import asyncio
 import os
 
-from mistralai import Mistral
+from mistralai.client import Mistral
 from mistralai.extra.exceptions import DeferredToolCallsException
 from mistralai.extra.run.context import RunContext
 
@@ -263,7 +263,7 @@ import asyncio
 import json
 import os
 
-from mistralai import Mistral
+from mistralai.client import Mistral
 from mistralai.extra.run.context import RunContext
 from mistralai.extra.exceptions import DeferredToolCallsException
 
@@ -305,7 +305,7 @@ import asyncio
 import json
 import os
 
-from mistralai import Mistral
+from mistralai.client import Mistral
 from mistralai.extra.run.context import RunContext
 from mistralai.extra.exceptions import DeferredToolCallsException, DeferredToolCallEntry
 

--- a/mistral/embeddings/code_embedding.ipynb
+++ b/mistral/embeddings/code_embedding.ipynb
@@ -109,7 +109,7 @@
     "import numpy as np\n",
     "from tqdm import tqdm\n",
     "from datasets import load_dataset\n",
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "from langchain.text_splitter import Language, RecursiveCharacterTextSplitter\n",
     "import faiss\n",
     "from collections import defaultdict\n",

--- a/mistral/embeddings/embeddings.ipynb
+++ b/mistral/embeddings/embeddings.ipynb
@@ -32,7 +32,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "\n",
     "api_key = os.environ[\"MISTRAL_API_KEY\"]\n",
     "model = \"mistral-embed\"\n",

--- a/mistral/evaluation/RAG_evaluation.ipynb
+++ b/mistral/evaluation/RAG_evaluation.ipynb
@@ -70,7 +70,7 @@
     "from enum import Enum\n",
     "from typing import List\n",
     "from getpass import getpass\n",
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "\n",
     "# Define the API key and model\n",
     "api_key = getpass(\"Enter Mistral AI API Key\")"
@@ -120,7 +120,7 @@
     "from pydantic import BaseModel, Field\n",
     "from enum import Enum\n",
     "from getpass import getpass\n",
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "\n",
     "# Initialize the Mistral client with the API key\n",
     "client = Mistral(api_key=api_key)\n",

--- a/mistral/evaluation/evaluation.ipynb
+++ b/mistral/evaluation/evaluation.ipynb
@@ -35,7 +35,7 @@
     }
    ],
    "source": [
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "from getpass import getpass\n",
     "\n",
     "api_key= getpass(\"Type your API Key\")\n",

--- a/mistral/fine_tune/mistral_finetune_api.ipynb
+++ b/mistral/fine_tune/mistral_finetune_api.ipynb
@@ -213,7 +213,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "import os\n",
         "\n",
         "api_key = os.environ[\"MISTRAL_API_KEY\"]\n",

--- a/mistral/fine_tune/pixtral_finetune_on_satellite_data.ipynb
+++ b/mistral/fine_tune/pixtral_finetune_on_satellite_data.ipynb
@@ -664,7 +664,7 @@
         "# Mistral's schemas\n",
         "# ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~\n",
         "\n",
-        "from mistralai.models import UserMessage, SystemMessage, AssistantMessage\n",
+        "from mistralai.client.models import UserMessage, SystemMessage, AssistantMessage\n",
         "\n",
         "def _template_inference_message(\n",
         "    img_b64: str\n",
@@ -912,7 +912,7 @@
       ],
       "source": [
         "from getpass import getpass\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "api_key= getpass(\"Type your API Key\")\n",
         "client = Mistral(api_key=api_key)\n",

--- a/mistral/function_calling/function_calling.ipynb
+++ b/mistral/function_calling/function_calling.ipynb
@@ -240,7 +240,7 @@
       ],
       "source": [
         "import os\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "api_key = os.environ[\"MISTRAL_API_KEY\"]\n",
         "model = \"mistral-large-latest\"\n",

--- a/mistral/function_calling/text_to_SQL.ipynb
+++ b/mistral/function_calling/text_to_SQL.ipynb
@@ -248,7 +248,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from getpass import getpass\n",
         "\n",
         "# To interract with the SQL database\n",

--- a/mistral/image_understanding/batch_api_example.ipynb
+++ b/mistral/image_understanding/batch_api_example.ipynb
@@ -587,7 +587,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "import os\n",
     "\n",
     "api_key = os.environ[\"MISTRAL_API_KEY\"]\n",

--- a/mistral/image_understanding/image_description_prompting_pixtral.ipynb
+++ b/mistral/image_understanding/image_description_prompting_pixtral.ipynb
@@ -116,7 +116,7 @@
       "outputs": [],
       "source": [
         "import os\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "# Load Mistral API key from environment variables\n",
         "api_key = os.environ[\"MISTRAL_API_KEY\"]\n",

--- a/mistral/image_understanding/multimodality_meets_function_calling.ipynb
+++ b/mistral/image_understanding/multimodality_meets_function_calling.ipynb
@@ -62,7 +62,7 @@
         "from dotenv import load_dotenv\n",
         "from PIL import Image as PILImage\n",
         "import os \n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "import json\n",
         "import pandas as pd\n",
         "import requests"
@@ -146,7 +146,7 @@
       "source": [
         "import base64\n",
         "import os\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "def encode_image(image_path):\n",
         "    \"\"\"Encode the image to base64.\"\"\"\n",

--- a/mistral/lechat_custom_mcp_server/tic-tac-toe/README.md
+++ b/mistral/lechat_custom_mcp_server/tic-tac-toe/README.md
@@ -29,7 +29,7 @@ LeChat ←→ SSE Transport ←→ Your MCP Server ←→ Game Logic + Mistral A
 tictactoe-mcp-server/
 ├── mcp_server.py      # Main MCP server code
 ├── app.py             # Game logic and Flask API
-├── requirements.txt   # Python dependencies  
+├── requirements.txt   # Python dependencies
 ├── Dockerfile        # For Hugging Face deployment
 ```
 
@@ -79,18 +79,18 @@ When your MCP server is deployed, you'll have:
 - **Game state** needs to persist across interactions
 
 A simple single-game approach won't work because:
-❌ Users would interfere with each other's games  
-❌ No way to resume games later  
-❌ Can't support multiple concurrent games  
+❌ Users would interfere with each other's games
+❌ No way to resume games later
+❌ Can't support multiple concurrent games
 ❌ State gets lost between MCP tool calls
 
 ### The Solution: Room-Based Sessions
 
 We create a **"Room"** for each game session:
-✅ **Isolated state** - Each game has its own board and history  
-✅ **Unique identifiers** - Room IDs prevent game conflicts  
-✅ **Persistent sessions** - Games survive between tool calls  
-✅ **Multi-room support** - Users can play multiple games  
+✅ **Isolated state** - Each game has its own board and history
+✅ **Unique identifiers** - Room IDs prevent game conflicts
+✅ **Persistent sessions** - Games survive between tool calls
+✅ **Multi-room support** - Users can play multiple games
 ✅ **Easy cleanup** - Old rooms can be removed when inactive
 
 ### What We're Building
@@ -100,7 +100,7 @@ We create a **"Room"** for each game session:
 User 1 ─┬─ Room ABC123 (Active game vs AI)
          └─ Room DEF456 (Finished game)
 
-User 2 ─┬─ Room GHI789 (Their current game)  
+User 2 ─┬─ Room GHI789 (Their current game)
          └─ Room JKL012 (Another game)
 
 User 3 ─── Room MNO345 (New game starting)
@@ -133,7 +133,7 @@ The `Room` class is the heart of our game logic. It encapsulates everything need
 
 ##### What the Room Class Does:
 - **State Management**: Tracks board positions, whose turn, win/draw status
-- **Session Isolation**: Each room is independent - no games interfere with each other  
+- **Session Isolation**: Each room is independent - no games interfere with each other
 - **AI Integration**: Coordinates with Mistral AI for intelligent gameplay
 - **Chat System**: Maintains conversation history between human and AI
 - **Data Persistence**: Survives between MCP tool calls
@@ -149,7 +149,7 @@ import time
 from flask import Flask, request, jsonify, render_template, send_from_directory
 from flask_cors import CORS
 import logging
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 # Flask app setup
 app = Flask(__name__)
@@ -178,7 +178,7 @@ class Room:
         self.created = time.time()
         self.last_activity = time.time()
         self.moves_count = 0
-        
+
         # Add welcome message
         self.chat_history.append({
             'sender': 'ai',
@@ -193,14 +193,14 @@ Now we'll add the core methods that make our tic-tac-toe game work. Each method 
 
 ###### Methods We're Adding:
 - **`make_move(position, player)`**: Validates and executes moves, checks for wins
-- **`check_winner()`**: Determines if someone has won the game  
+- **`check_winner()`**: Determines if someone has won the game
 - **`add_chat_message(message, sender)`**: Manages conversation history
 - **`to_markdown()`**: Creates beautiful game display for users
 - **`to_dict()`**: Converts room to JSON format for API responses
 
 ###### Why These Methods?
 - **Game Rules**: `make_move()` and `check_winner()` enforce tic-tac-toe rules
-- **User Experience**: `to_markdown()` makes games visually appealing  
+- **User Experience**: `to_markdown()` makes games visually appealing
 - **Communication**: `add_chat_message()` enables AI personality
 - **API Integration**: `to_dict()` provides structured data for MCP tools
 
@@ -211,11 +211,11 @@ Add these methods to the `Room` class:
         """Make a move on the board"""
         if self.game_status != 'active' or self.board[position] != '':
             return False
-        
+
         self.board[position] = player
         self.moves_count += 1
         self.last_activity = time.time()
-        
+
         # Check for winner
         if self.check_winner():
             self.game_status = 'won'
@@ -224,9 +224,9 @@ Add these methods to the `Room` class:
             self.game_status = 'draw'
         else:
             self.current_player = 'O' if player == 'X' else 'X'
-        
+
         return True
-    
+
     def check_winner(self):
         """Check if there's a winner"""
         win_patterns = [
@@ -234,13 +234,13 @@ Add these methods to the `Room` class:
             [0, 3, 6], [1, 4, 7], [2, 5, 8],  # columns
             [0, 4, 8], [2, 4, 6]              # diagonals
         ]
-        
+
         for pattern in win_patterns:
             a, b, c = pattern
             if self.board[a] and self.board[a] == self.board[b] == self.board[c]:
                 return True
         return False
-    
+
     def add_chat_message(self, message, sender):
         """Add a chat message to history"""
         self.chat_history.append({
@@ -249,12 +249,12 @@ Add these methods to the `Room` class:
             'timestamp': time.time()
         })
         self.last_activity = time.time()
-    
+
     def to_markdown(self):
         """Convert game state to markdown for display"""
         markdown = f"# Game Room: {self.id}\n"
         markdown += f"## Status: "
-        
+
         if self.game_status == 'won':
             winner_name = "You" if self.winner == 'X' else "Mistral AI"
             markdown += f"Game Over - {winner_name} wins! 🎉\n"
@@ -263,9 +263,9 @@ Add these methods to the `Room` class:
         else:
             turn_name = "Your turn" if self.current_player == 'X' else "Mistral's turn"
             markdown += f"{turn_name} ({self.current_player} to play)\n"
-        
+
         markdown += f"Moves: {self.moves_count}/9\n\n"
-        
+
         # Board representation
         markdown += "```\n"
         for i in range(0, 9, 3):
@@ -274,7 +274,7 @@ Add these methods to the `Room` class:
             if i < 6:
                 markdown += "-----------\n"
         markdown += "```\n\n"
-        
+
         # Recent chat history
         if self.chat_history:
             markdown += "## Recent Chat\n"
@@ -282,9 +282,9 @@ Add these methods to the `Room` class:
             for msg in recent_messages:
                 sender_name = "**You:**" if msg['sender'] == 'user' else "**Mistral AI:**"
                 markdown += f"{sender_name} {msg['message']}\n"
-        
+
         return markdown
-    
+
     def to_dict(self):
         """Convert room to dictionary"""
         return {
@@ -319,14 +319,14 @@ The AI opponent is what makes this game engaging! We need two functions to handl
 
 ###### Why AI Integration?
 - **Intelligent Opponent**: AI analyzes the board and makes strategic moves
-- **Personality**: AI responds with witty comments and competitive banter  
+- **Personality**: AI responds with witty comments and competitive banter
 - **Engagement**: Makes the game fun and interactive, not just mechanical
 - **Context Awareness**: AI sees current game state and responds appropriately
 
 ###### How It Works:
 1. **Game State Analysis**: AI receives current board layout
 2. **Strategic Thinking**: AI evaluates possible moves and picks the best one
-3. **Personality Response**: AI adds a comment about the move or situation  
+3. **Personality Response**: AI adds a comment about the move or situation
 4. **JSON Response**: Returns structured data with move and message
 
 Add these functions for AI opponent:
@@ -340,7 +340,7 @@ def get_ai_move_for_room(room):
         board_string += f"{row[0]} | {row[1]} | {row[2]}\n"
         if i < 6:
             board_string += "---------\n"
-    
+
     messages = [
         {
             "role": "system",
@@ -368,14 +368,14 @@ Board positions:
             "content": f"Current board:\n{board_string}\n\nBoard array: {room.board}"
         }
     ]
-    
+
     response = client.chat.complete(
         model="mistral-large-latest",
         messages=messages,
         temperature=0.1,
         response_format={"type": "json_object"}
     )
-    
+
     return json.loads(response.choices[0].message.content)
 
 def get_ai_chat_for_room(room, user_message):
@@ -386,7 +386,7 @@ def get_ai_chat_for_room(room, user_message):
         board_string += f"{row[0]} | {row[1]} | {row[2]}\n"
         if i < 6:
             board_string += "---------\n"
-    
+
     messages = [
         {
             "role": "system",
@@ -403,12 +403,12 @@ Keep responses under 50 words. Use emojis occasionally. Don't make game moves in
             "content": user_message
         }
     ]
-    
+
     response = client.chat.complete(
         model="mistral-large-latest",
         messages=messages
     )
-    
+
     return response.choices[0].message.content
 ```
 
@@ -419,7 +419,7 @@ Now we create REST API endpoints so you can test the game logic locally before a
 ##### Endpoints We're Building:
 - **`POST /rooms`**: Creates a new game room - starts a fresh game
 - **`GET /rooms/<room_id>`**: Gets current room state - check game status anytime
-- **`POST /rooms/<room_id>/move`**: Makes a move - handles human move + AI response  
+- **`POST /rooms/<room_id>/move`**: Makes a move - handles human move + AI response
 - **`POST /rooms/<room_id>/chat`**: Sends chat message - talk with AI during game
 
 ##### Why These Endpoints?
@@ -430,7 +430,7 @@ Now we create REST API endpoints so you can test the game logic locally before a
 
 ##### API Design Philosophy:
 - **RESTful**: Standard HTTP methods for predictable behavior
-- **Room-Centric**: All operations revolve around room IDs  
+- **Room-Centric**: All operations revolve around room IDs
 - **Rich Responses**: Include both raw data and formatted markdown
 - **Error Handling**: Clear error messages for debugging
 
@@ -455,7 +455,7 @@ def get_room(room_id):
     """Get room state"""
     if room_id not in rooms:
         return jsonify({'error': 'Room not found'}), 404
-    
+
     room = rooms[room_id]
     return jsonify({
         'room_id': room_id,
@@ -468,18 +468,18 @@ def make_room_move(room_id):
     """Make a move in the game"""
     if room_id not in rooms:
         return jsonify({'error': 'Room not found'}), 404
-    
+
     room = rooms[room_id]
     data = request.json
     position = data.get('position')
-    
+
     if position is None or position < 0 or position > 8:
         return jsonify({'error': 'Invalid position'}), 400
-    
+
     # Make human move
     if not room.make_move(position, 'X'):
         return jsonify({'error': 'Invalid move'}), 400
-    
+
     # Check if game ended
     if room.game_status != 'active':
         return jsonify({
@@ -487,7 +487,7 @@ def make_room_move(room_id):
             'markdown': room.to_markdown(),
             'ai_move': None
         })
-    
+
     # Get AI move
     try:
         ai_response = get_ai_move_for_room(room)
@@ -497,7 +497,7 @@ def make_room_move(room_id):
                 room.make_move(ai_move, 'O')
                 if 'message' in ai_response:
                     room.add_chat_message(ai_response['message'], 'ai')
-        
+
         return jsonify({
             'room_data': room.to_dict(),
             'markdown': room.to_markdown(),
@@ -512,22 +512,22 @@ def room_chat(room_id):
     """Send a chat message"""
     if room_id not in rooms:
         return jsonify({'error': 'Room not found'}), 404
-    
+
     room = rooms[room_id]
     data = request.json
     user_message = data.get('message', '')
-    
+
     if not user_message.strip():
         return jsonify({'error': 'Empty message'}), 400
-    
+
     # Add user message
     room.add_chat_message(user_message, 'user')
-    
+
     # Get AI response
     try:
         ai_response = get_ai_chat_for_room(room, user_message)
         room.add_chat_message(ai_response, 'ai')
-        
+
         return jsonify({
             'room_data': room.to_dict(),
             'markdown': room.to_markdown(),
@@ -591,7 +591,7 @@ curl http://localhost:7860/rooms/YOUR_ROOM_ID
 
 **🎉 Success!** Your game logic foundation is solid. You now have:
 - A working tic-tac-toe engine
-- AI opponent integration  
+- AI opponent integration
 - REST API for testing
 - Rich data formatting
 - Proper error handling
@@ -612,9 +612,9 @@ MCP (Model Context Protocol) is a bridge between AI assistants and your applicat
 - **Formats Responses**: Converts your data into formats AI assistants understand
 
 MCP provides:
-✅ **Tool Interface** - AI can directly call game functions  
+✅ **Tool Interface** - AI can directly call game functions
 ✅ **Self-Documenting** - Each tool explains when to use it
-✅ **Session State** - Maintains game context between calls  
+✅ **Session State** - Maintains game context between calls
 ✅ **Rich Responses** - Formatted data that AI can present beautifully
 
 #### The Translation Layer
@@ -622,7 +622,7 @@ MCP provides:
 LeChat: "I want to play tic-tac-toe"
     ↓
 MCP: Calls create_room() tool
-    ↓  
+    ↓
 Your Game Logic: Creates new Room object
     ↓
 MCP: Returns formatted response with game board
@@ -634,7 +634,7 @@ LeChat: Shows beautiful tic-tac-toe board to user
 
 ##### What We're Building
 - **FastMCP Server**: The core MCP protocol handler
-- **Session State**: Tracks current user's active game  
+- **Session State**: Tracks current user's active game
 - **Tool Functions**: 6 functions that wrap our game logic
 - **SSE Transport**: Server-Sent Events for real-time communication
 
@@ -675,7 +675,7 @@ Now we'll create the foundational MCP tools that handle game room lifecycle.
 ##### How They Work:
 1. **AI Decides**: Based on user input, AI chooses which tool to call
 2. **MCP Validates**: Checks parameters and session state
-3. **Game Logic**: Calls our Room class methods  
+3. **Game Logic**: Calls our Room class methods
 4. **Response Formatting**: Converts results to AI-friendly format
 5. **Display**: AI presents formatted results to user
 
@@ -693,10 +693,10 @@ def create_room() -> dict:
     try:
         room = Room()
         rooms[room.id] = room
-        
+
         # Set as active room for this session
         current_session['active_room_id'] = room.id
-        
+
         return {
             "status": "success",
             "room_id": room.id,
@@ -728,21 +728,21 @@ def get_room_state(room_id: str = None) -> dict:
     try:
         # Use provided room_id or current active room
         target_room_id = room_id or current_session.get('active_room_id')
-        
+
         if not target_room_id:
             return {
                 "status": "error",
                 "message": "No active room. Create a room first using create_room()."
             }
-        
+
         if target_room_id not in rooms:
             return {
                 "status": "error",
                 "message": f"Room {target_room_id} not found. It may have been cleaned up."
             }
-        
+
         room = rooms[target_room_id]
-        
+
         return {
             "status": "success",
             "room_id": target_room_id,
@@ -759,7 +759,7 @@ def get_room_state(room_id: str = None) -> dict:
         }
 ```
 
-#### Step 3: Implement Game Play Tools  
+#### Step 3: Implement Game Play Tools
 
 This is where the magic happens! We'll create the tools that handle actual gameplay.
 
@@ -770,7 +770,7 @@ This is where the magic happens! We'll create the tools that handle actual gamep
 1. **Validation**: Check if move is legal (valid position, player's turn, game active)
 2. **Human Move**: Place X on the board, check for win/draw
 3. **AI Response**: If game continues, get AI's counter-move with personality
-4. **AI Move**: Place O on board, check for AI win/draw  
+4. **AI Move**: Place O on board, check for AI win/draw
 5. **Formatting**: Create beautiful response with game state and AI trash talk
 6. **Return**: Send everything back for AI to display to user
 
@@ -793,42 +793,42 @@ async def make_move(position: int, room_id: str = None) -> dict:
     try:
         # Use provided room_id or current active room
         target_room_id = room_id or current_session.get('active_room_id')
-        
+
         if not target_room_id:
             return {
                 "status": "error",
                 "message": "No active room. Create a room first using create_room()."
             }
-        
+
         if target_room_id not in rooms:
             return {
                 "status": "error",
                 "message": f"Room {target_room_id} not found."
             }
-        
+
         room = rooms[target_room_id]
-        
+
         # Validate move
         if position < 0 or position > 8:
             return {
                 "status": "error",
                 "message": "Invalid position. Use 0-8 (left to right, top to bottom)."
             }
-        
+
         if room.game_status != 'active':
             return {
                 "status": "error",
                 "message": f"Game is over. Status: {room.game_status}",
                 "markdown_state": room.to_markdown()
             }
-        
+
         if room.current_player != 'X':
             return {
                 "status": "error",
                 "message": "It's not your turn! Wait for AI to move.",
                 "markdown_state": room.to_markdown()
             }
-        
+
         # Make human move
         if not room.make_move(position, 'X'):
             return {
@@ -836,16 +836,16 @@ async def make_move(position: int, room_id: str = None) -> dict:
                 "message": f"Invalid move! Position {position} may already be occupied.",
                 "markdown_state": room.to_markdown()
             }
-        
+
         result_message = f"✅ You played X at position {position}\n\n"
-        
+
         # Check if game ended after human move
         if room.game_status != 'active':
             if room.winner == 'X':
                 result_message += "🎉 Congratulations! You won!\n\n"
             else:
                 result_message += "🤝 It's a draw!\n\n"
-            
+
             result_message += room.to_markdown()
             return {
                 "status": "success",
@@ -853,7 +853,7 @@ async def make_move(position: int, room_id: str = None) -> dict:
                 "game_over": True,
                 "winner": room.winner
             }
-        
+
         # Get AI move
         try:
             ai_response = get_ai_move_for_room(room)
@@ -863,13 +863,13 @@ async def make_move(position: int, room_id: str = None) -> dict:
                     room.make_move(ai_move, 'O')
                     if 'message' in ai_response:
                         room.add_chat_message(ai_response['message'], 'ai')
-                
+
                 result_message += f"🤖 Mistral AI played O at position {ai_response['move']}\n"
                 if 'message' in ai_response:
                     result_message += f"💬 Mistral says: \"{ai_response['message']}\"\n\n"
                 else:
                     result_message += "\n"
-                
+
                 # Check if AI won
                 if room.game_status == 'won' and room.winner == 'O':
                     result_message += "💀 Mistral AI wins this round!\n\n"
@@ -877,12 +877,12 @@ async def make_move(position: int, room_id: str = None) -> dict:
                     result_message += "🤝 It's a draw!\n\n"
             else:
                 result_message += "⚠️ AI move failed, but you can continue\n\n"
-                
+
         except Exception as e:
             result_message += f"⚠️ AI move error: {str(e)}\n\n"
-        
+
         result_message += room.to_markdown()
-        
+
         return {
             "status": "success",
             "message": result_message,
@@ -890,7 +890,7 @@ async def make_move(position: int, room_id: str = None) -> dict:
             "winner": room.winner if room.game_status == 'won' else None,
             "your_turn": room.current_player == 'X' and room.game_status == 'active'
         }
-        
+
     except Exception as e:
         return {
             "status": "error",
@@ -904,7 +904,7 @@ Now we'll add the remaining tools that make the game experience complete and use
 
 ##### Remaining Tools:
 - **`send_chat(message, room_id)`**: Talk with AI opponent during games
-- **`list_rooms()`**: See all active game sessions  
+- **`list_rooms()`**: See all active game sessions
 - **`get_help()`**: Show instructions and available commands
 
 Complete the MCP server with chat and helper tools:
@@ -923,38 +923,38 @@ async def send_chat(message: str, room_id: str = None) -> dict:
     global current_session
     try:
         target_room_id = room_id or current_session.get('active_room_id')
-        
+
         if not target_room_id:
             return {
                 "status": "error",
                 "message": "No active room. Create a room first using create_room()."
             }
-        
+
         if target_room_id not in rooms:
             return {
                 "status": "error",
                 "message": f"Room {target_room_id} not found."
             }
-        
+
         room = rooms[target_room_id]
-        
+
         # Add user message
         room.add_chat_message(message, 'user')
-        
+
         # Get AI response
         ai_response = get_ai_chat_for_room(room, message)
         room.add_chat_message(ai_response, 'ai')
-        
+
         result_message = f"💬 **You:** {message}\n💬 **Mistral AI:** {ai_response}\n\n"
         result_message += room.to_markdown()
-        
+
         return {
             "status": "success",
             "message": result_message,
             "your_message": message,
             "ai_response": ai_response
         }
-        
+
     except Exception as e:
         return {
             "status": "error",
@@ -976,7 +976,7 @@ def list_rooms() -> dict:
                 "active_rooms": [],
                 "count": 0
             }
-        
+
         room_list = []
         for room_id, room in rooms.items():
             room_info = {
@@ -989,12 +989,12 @@ def list_rooms() -> dict:
                 "is_active": current_session.get('active_room_id') == room_id
             }
             room_list.append(room_info)
-        
+
         active_room_id = current_session.get('active_room_id')
         message = f"Found {len(room_list)} active rooms."
         if active_room_id:
             message += f" Current active room: {active_room_id}"
-        
+
         return {
             "status": "success",
             "message": message,
@@ -1063,7 +1063,7 @@ Finally, we'll add the code that actually starts our MCP server and makes it ava
 ##### What Server Startup Does:
 - **Initializes MCP**: Starts the FastMCP server instance
 - **Binds to Port**: Makes server accessible on port 7860 (Hugging Face standard)
-- **Enables SSE**: Sets up Server-Sent Events transport for real-time communication  
+- **Enables SSE**: Sets up Server-Sent Events transport for real-time communication
 - **Logs Status**: Shows what tools are available and confirms readiness
 
 Add the server startup code:
@@ -1101,7 +1101,7 @@ Now let's understand how our 6 tools work together to create a complete gaming e
 - **`make_move(position)`**: **Core gameplay** - Handles human moves + AI responses in one action
 - **`get_room_state()`**: **Status check** - Shows current board, whose turn, game outcome
 
-##### Enhanced Experience Tools:  
+##### Enhanced Experience Tools:
 - **`send_chat(message)`**: **Social interaction** - Talk with AI opponent, add personality
 - **`list_rooms()`**: **Session management** - Navigate between multiple concurrent games
 - **`get_help()`**: **User guidance** - Instructions and tips for new players
@@ -1110,7 +1110,7 @@ Now let's understand how our 6 tools work together to create a complete gaming e
 ```
 User: "Let's play tic-tac-toe"
 → AI calls: create_room()
-→ User: "I'll take the center"  
+→ User: "I'll take the center"
 → AI calls: make_move(4)
 → User: "Good move!"
 → AI calls: send_chat("Good move!")
@@ -1127,7 +1127,7 @@ Now let's deploy your MCP server to Hugging Face Spaces so it's accessible to Le
 ### Why Hugging Face Spaces?
 
 - **Free hosting** for personal projects
-- **Docker support** for custom environments  
+- **Docker support** for custom environments
 - **HTTPS by default** (required for MCP/SSE)
 - **Easy deployment** from Git repositories
 - **Automatic restarts** and health monitoring
@@ -1139,7 +1139,7 @@ Ensure your project structure looks like this:
 ```
 tictactoe-mcp-server/
 ├── mcp_server.py      ✅ Your MCP server
-├── app.py             ✅ Game logic & Flask API  
+├── app.py             ✅ Game logic & Flask API
 ├── requirements.txt   ✅ Dependencies
 ├── Dockerfile         ✅ Container setup
 └── README.md          ✅ Documentation
@@ -1201,7 +1201,7 @@ cd tictactoe-mcp-server
 
 # Copy your files (excluding .env)
 cp ../path/to/your/project/mcp_server.py .
-cp ../path/to/your/project/app.py .  
+cp ../path/to/your/project/app.py .
 cp ../path/to/your/project/requirements.txt .
 cp ../path/to/your/project/Dockerfile .
 cp ../path/to/your/project/README.md .
@@ -1326,7 +1326,7 @@ If you see errors, double-check:
 Confirm your MCP connector is active and ready to use.
 
 **Success indicators:**
-- ✅ **Active connection** indicator  
+- ✅ **Active connection** indicator
 - ✅ **Tools available** - LeChat can see your MCP tools
 
 **What happens next:**
@@ -1342,7 +1342,7 @@ Confirm your MCP connector is active and ready to use.
 🎉 **Congratulations!** You now have:
 
 - ✅ **Custom MCP Server** deployed and running
-- ✅ **LeChat Integration** with real-time communication  
+- ✅ **LeChat Integration** with real-time communication
 - ✅ **Interactive Gameplay** with intelligent AI opponent
 - ✅ **Rich Experience** with markdown game boards and chat
 - ✅ **Multi-Session Support** for concurrent games
@@ -1353,7 +1353,7 @@ You've built a complete **end-to-end integration** from custom application logic
 
 1. **Game Logic Foundation** - Room-based tic-tac-toe with AI
 2. **MCP Server Layer** - Tools that AI assistants can call
-3. **Cloud Deployment** - Production server on Hugging Face Spaces  
+3. **Cloud Deployment** - Production server on Hugging Face Spaces
 4. **Chat Integration** - Real-time gameplay in conversational interface
 
 **You've mastered the complete MCP development workflow on LeChat** 🚀

--- a/mistral/lechat_custom_mcp_server/tic-tac-toe/app.py
+++ b/mistral/lechat_custom_mcp_server/tic-tac-toe/app.py
@@ -5,7 +5,7 @@ import logging
 import json
 import uuid
 import time
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 app = Flask(__name__)
 CORS(app)
@@ -33,22 +33,22 @@ class Room:
         self.created = time.time()
         self.last_activity = time.time()
         self.moves_count = 0
-        
+
         # Add welcome message
         self.chat_history.append({
             'sender': 'ai',
             'message': "Hey there! Ready for a game of Tic-Tac-Toe? I'm pretty good at this... 😏 You're X, I'm O. Good luck!",
             'timestamp': time.time()
         })
-    
+
     def make_move(self, position, player):
         if self.game_status != 'active' or self.board[position] != '':
             return False
-        
+
         self.board[position] = player
         self.moves_count += 1
         self.last_activity = time.time()
-        
+
         # Check for winner
         if self.check_winner():
             self.game_status = 'won'
@@ -57,22 +57,22 @@ class Room:
             self.game_status = 'draw'
         else:
             self.current_player = 'O' if player == 'X' else 'X'
-        
+
         return True
-    
+
     def check_winner(self):
         win_patterns = [
             [0, 1, 2], [3, 4, 5], [6, 7, 8],  # rows
             [0, 3, 6], [1, 4, 7], [2, 5, 8],  # columns
             [0, 4, 8], [2, 4, 6]              # diagonals
         ]
-        
+
         for pattern in win_patterns:
             a, b, c = pattern
             if self.board[a] and self.board[a] == self.board[b] == self.board[c]:
                 return True
         return False
-    
+
     def add_chat_message(self, message, sender):
         self.chat_history.append({
             'sender': sender,
@@ -80,12 +80,12 @@ class Room:
             'timestamp': time.time()
         })
         self.last_activity = time.time()
-    
+
     def to_markdown(self):
         # Game header
         markdown = f"# Game Room: {self.id}\n"
         markdown += f"## Status: "
-        
+
         if self.game_status == 'won':
             winner_name = "You" if self.winner == 'X' else "Mistral AI"
             markdown += f"Game Over - {winner_name} wins! 🎉\n"
@@ -94,9 +94,9 @@ class Room:
         else:
             turn_name = "Your turn" if self.current_player == 'X' else "Mistral's turn"
             markdown += f"{turn_name} ({self.current_player} to play)\n"
-        
+
         markdown += f"Moves: {self.moves_count}/9\n\n"
-        
+
         # Board representation
         markdown += "```\n"
         for i in range(0, 9, 3):
@@ -105,7 +105,7 @@ class Room:
             if i < 6:
                 markdown += "-----------\n"
         markdown += "```\n\n"
-        
+
         # Chat history (last 5 messages)
         if self.chat_history:
             markdown += "## Recent Chat\n"
@@ -113,9 +113,9 @@ class Room:
             for msg in recent_messages:
                 sender_name = "**You:**" if msg['sender'] == 'user' else "**Mistral AI:**"
                 markdown += f"{sender_name} {msg['message']}\n"
-        
+
         return markdown
-    
+
     def to_dict(self):
         return {
             'id': self.id,
@@ -148,7 +148,7 @@ def create_room():
 def get_room(room_id):
     if room_id not in rooms:
         return jsonify({'error': 'Room not found'}), 404
-    
+
     room = rooms[room_id]
     return jsonify({
         'room_id': room_id,
@@ -160,18 +160,18 @@ def get_room(room_id):
 def make_room_move(room_id):
     if room_id not in rooms:
         return jsonify({'error': 'Room not found'}), 404
-    
+
     room = rooms[room_id]
     data = request.json
     position = data.get('position')
-    
+
     if position is None or position < 0 or position > 8:
         return jsonify({'error': 'Invalid position'}), 400
-    
+
     # Make human move
     if not room.make_move(position, 'X'):
         return jsonify({'error': 'Invalid move'}), 400
-    
+
     # Check if game ended
     if room.game_status != 'active':
         return jsonify({
@@ -179,7 +179,7 @@ def make_room_move(room_id):
             'markdown': room.to_markdown(),
             'ai_move': None
         })
-    
+
     # Get AI move
     try:
         ai_response = get_ai_move_for_room(room)
@@ -198,7 +198,7 @@ def make_room_move(room_id):
                     fallback_move = empty_positions[0]  # Take first available
                     room.make_move(fallback_move, 'O')
                     room.add_chat_message("Oops, had a brain freeze! But I'm still playing! 🤖", 'ai')
-        
+
         return jsonify({
             'room_data': room.to_dict(),
             'markdown': room.to_markdown(),
@@ -212,7 +212,7 @@ def make_room_move(room_id):
             fallback_move = empty_positions[0]
             room.make_move(fallback_move, 'O')
             room.add_chat_message("Technical difficulties, but I'm improvising! 😅", 'ai')
-        
+
         return jsonify({
             'room_data': room.to_dict(),
             'markdown': room.to_markdown(),
@@ -223,22 +223,22 @@ def make_room_move(room_id):
 def room_chat(room_id):
     if room_id not in rooms:
         return jsonify({'error': 'Room not found'}), 404
-    
+
     room = rooms[room_id]
     data = request.json
     user_message = data.get('message', '')
-    
+
     if not user_message.strip():
         return jsonify({'error': 'Empty message'}), 400
-    
+
     # Add user message
     room.add_chat_message(user_message, 'user')
-    
+
     # Get AI response
     try:
         ai_response = get_ai_chat_for_room(room, user_message)
         room.add_chat_message(ai_response, 'ai')
-        
+
         return jsonify({
             'room_data': room.to_dict(),
             'markdown': room.to_markdown(),
@@ -252,7 +252,7 @@ def room_chat(room_id):
 def get_room_markdown(room_id):
     if room_id not in rooms:
         return jsonify({'error': 'Room not found'}), 404
-    
+
     room = rooms[room_id]
     return jsonify({
         'room_id': room_id,
@@ -267,7 +267,7 @@ def get_ai_move_for_room(room):
         board_string += f"{row[0]} | {row[1]} | {row[2]}\n"
         if i < 6:
             board_string += "---------\n"
-    
+
     messages = [
         {
             "role": "system",
@@ -295,14 +295,14 @@ Board positions:
             "content": f"Current board:\n{board_string}\n\nBoard array: {room.board}"
         }
     ]
-    
+
     response = client.chat.complete(
         model="mistral-large-latest",
         messages=messages,
         temperature=0.1,
         response_format={"type": "json_object"}
     )
-    
+
     return json.loads(response.choices[0].message.content)
 
 def get_ai_chat_for_room(room, user_message):
@@ -312,7 +312,7 @@ def get_ai_chat_for_room(room, user_message):
         board_string += f"{row[0]} | {row[1]} | {row[2]}\n"
         if i < 6:
             board_string += "---------\n"
-    
+
     messages = [
         {
             "role": "system",
@@ -329,12 +329,12 @@ Keep responses under 50 words. Use emojis occasionally. Don't make game moves in
             "content": user_message
         }
     ]
-    
+
     response = client.chat.complete(
         model="mistral-large-latest",
         messages=messages
     )
-    
+
     return response.choices[0].message.content
 
 # Serve the room-based game page

--- a/mistral/moderation/moderation-explored.ipynb
+++ b/mistral/moderation/moderation-explored.ipynb
@@ -112,7 +112,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "api_key = \"API_KEY\"\n",
         "\n",

--- a/mistral/moderation/system-level-guardrails.ipynb
+++ b/mistral/moderation/system-level-guardrails.ipynb
@@ -112,7 +112,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "api_key = \"API_KEY\"\n",
         "\n",

--- a/mistral/ocr/batch_ocr.ipynb
+++ b/mistral/ocr/batch_ocr.ipynb
@@ -124,7 +124,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "api_key = \"API_KEY\"\n",
         "client = Mistral(api_key=api_key)\n",

--- a/mistral/ocr/data_extraction.ipynb
+++ b/mistral/ocr/data_extraction.ipynb
@@ -111,7 +111,7 @@
       "outputs": [],
       "source": [
         "# Initialize Mistral client with API key\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "api_key = \"API_KEY\" # Replace with your API key\n",
         "client = Mistral(api_key=api_key)"
@@ -458,7 +458,7 @@
         }
       ],
       "source": [
-        "from mistralai.models import OCRResponse\n",
+        "from mistralai.client.models import OCRResponse\n",
         "from IPython.display import Markdown, display\n",
         "\n",
         "def replace_images_in_markdown(markdown_str: str, images_dict: dict) -> str:\n",

--- a/mistral/ocr/document_understanding.ipynb
+++ b/mistral/ocr/document_understanding.ipynb
@@ -135,7 +135,7 @@
     {
       "cell_type": "code",
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "api_key = \"API_KEY\"\n",
         "client = Mistral(api_key=api_key)\n",

--- a/mistral/ocr/hcls/ocr_hcls.ipynb
+++ b/mistral/ocr/hcls/ocr_hcls.ipynb
@@ -142,7 +142,7 @@
       "source": [
         "# Initialize Mistral client with API key\n",
         "import os\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from google.colab import userdata\n",
         "import requests\n",
         "\n",
@@ -291,7 +291,7 @@
       "outputs": [],
       "source": [
         "from IPython.display import display, HTML, Markdown\n",
-        "from mistralai.models import OCRResponse\n",
+        "from mistralai.client.models import OCRResponse\n",
         "from bs4 import BeautifulSoup\n",
         "\n",
         "# CSS styling for tables (reusable constant)\n",
@@ -730,7 +730,7 @@
         "from collections import Counter\n",
         "\n",
         "from pydantic import BaseModel, Field, JsonValue\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from mistralai.extra import response_format_from_pydantic_model\n",
         "from google.colab import userdata\n",
         "\n",

--- a/mistral/ocr/product_datasheet_analysis/product_datasheet_analysis.ipynb
+++ b/mistral/ocr/product_datasheet_analysis/product_datasheet_analysis.ipynb
@@ -84,7 +84,7 @@
     "import base64\n",
     "import os\n",
     "import json\n",
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "from mistralai.extra import response_format_from_pydantic_model\n",
     "from pydantic import BaseModel, Field\n",
     "from typing import List, Optional\n",

--- a/mistral/ocr/structured_ocr.ipynb
+++ b/mistral/ocr/structured_ocr.ipynb
@@ -90,7 +90,7 @@
       "outputs": [],
       "source": [
         "# Initialize Mistral client with API key\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "api_key = \"API_KEY\" # Replace with your API key\n",
         "client = Mistral(api_key=api_key)"
@@ -200,7 +200,7 @@
         }
       ],
       "source": [
-        "from mistralai.models import OCRResponse\n",
+        "from mistralai.client.models import OCRResponse\n",
         "from IPython.display import Markdown, display\n",
         "\n",
         "def replace_images_in_markdown(markdown_str: str, images_dict: dict) -> str:\n",

--- a/mistral/ocr/tool_usage.ipynb
+++ b/mistral/ocr/tool_usage.ipynb
@@ -122,7 +122,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "api_key = \"API_KEY\"\n",
         "client = Mistral(api_key=api_key)\n",

--- a/mistral/prompting/prefix_use_cases.ipynb
+++ b/mistral/prompting/prefix_use_cases.ipynb
@@ -115,7 +115,7 @@
         }
       ],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from getpass import getpass\n",
         "\n",
         "api_key= getpass(\"Type your API Key\")\n",

--- a/mistral/prompting/prompting_capabilities.ipynb
+++ b/mistral/prompting/prompting_capabilities.ipynb
@@ -38,7 +38,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral"
+        "from mistralai.client import Mistral"
       ]
     },
     {

--- a/mistral/rag/RAG_via_function_calling.ipynb
+++ b/mistral/rag/RAG_via_function_calling.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "from getpass import getpass\n",
     "import json"
    ]

--- a/mistral/rag/basic_RAG.ipynb
+++ b/mistral/rag/basic_RAG.ipynb
@@ -65,7 +65,7 @@
     }
    ],
    "source": [
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "import requests\n",
     "import numpy as np\n",
     "import faiss\n",

--- a/mistral/rag/mistral-reference-rag.ipynb
+++ b/mistral/rag/mistral-reference-rag.ipynb
@@ -60,8 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mistralai import Mistral\n",
-    "from mistralai.models import  UserMessage, SystemMessage\n",
+    "from mistralai.client import Mistral\n",
+    "from mistralai.client.models import  UserMessage, SystemMessage\n",
     "import os\n",
     "\n",
     "client = Mistral(\n",
@@ -304,7 +304,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mistralai.models import TextChunk, ReferenceChunk\n",
+    "from mistralai.client.models import TextChunk, ReferenceChunk\n",
     "\n",
     "def format_response(chat_response: list, wb_result:dict):\n",
     "    print(\"\\n🤖 Answer:\\n\")\n",

--- a/quickstart.ipynb
+++ b/quickstart.ipynb
@@ -65,7 +65,7 @@
         }
       ],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "api_key = \"TYPE YOUR API KEY\"\n",
         "model = \"mistral-large-latest\"\n",
         "\n",

--- a/third_party/Azure_AI_Search/azure_ai_search_rag.ipynb
+++ b/third_party/Azure_AI_Search/azure_ai_search_rag.ipynb
@@ -144,7 +144,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "\n",
     "import getpass  # for securely inputting API key\n",
     "\n",
@@ -547,7 +547,7 @@
     }
    ],
    "source": [
-    "from mistralai import Mistral, SystemMessage, UserMessage\n",
+    "from mistralai.client import Mistral, SystemMessage, UserMessage\n",
     "\n",
     "# Initialize the client\n",
     "client = Mistral(api_key=mistral_api_key)\n",
@@ -584,7 +584,7 @@
    ],
    "source": [
     "import getpass\n",
-    "from mistralai import Mistral, SystemMessage, UserMessage\n",
+    "from mistralai.client import Mistral, SystemMessage, UserMessage\n",
     "\n",
     "azure_ai_studio_mistral_base_url = os.getenv(\"AZURE_AI_STUDIO_MISTRAL_BASE_URL\") or getpass.getpass(\"Enter your Azure Mistral Deployed Endpoint Base URL: \")\n",
     "azure_ai_studio_mistral_api_key = os.getenv(\"AZURE_AI_STUDIO_MISTRAL_API_KEY\") or getpass.getpass(\"Enter your Azure Mistral API Key: \")\n",

--- a/third_party/ChromaDB/chroma_mistral_embed_fn.ipynb
+++ b/third_party/ChromaDB/chroma_mistral_embed_fn.ipynb
@@ -53,7 +53,7 @@
         "import getpass\n",
         "import chromadb\n",
         "\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from datetime import datetime\n",
         "\n",
         "from chromadb import Documents, EmbeddingFunction, Embeddings"

--- a/third_party/Langfuse/cookbook_langfuse_mistral_sdk_integration.ipynb
+++ b/third_party/Langfuse/cookbook_langfuse_mistral_sdk_integration.ipynb
@@ -105,7 +105,7 @@
       },
       "outputs": [],
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "\n",
         "# Initialize Mistral client\n",
         "mistral_client = Mistral(api_key=os.environ[\"MISTRAL_API_KEY\"])"

--- a/third_party/MLflow/mistral-mlflow-tracing.ipynb
+++ b/third_party/MLflow/mistral-mlflow-tracing.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "import os\n",
     "\n",
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "\n",
     "import mlflow\n",
     "\n",

--- a/third_party/Maxim/cookbook_maxim_mistral_integration.ipynb
+++ b/third_party/Maxim/cookbook_maxim_mistral_integration.ipynb
@@ -208,7 +208,7 @@
     {
       "cell_type": "code",
       "source": [
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "from maxim.logger.mistral import MaximMistralClient\n",
         "import os\n",
         "\n",

--- a/third_party/Neo4j/neo4j_rag.ipynb
+++ b/third_party/Neo4j/neo4j_rag.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "import json\n",
     "from neo4j import GraphDatabase\n",
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "from getpass import getpass"
    ]
   },

--- a/third_party/Phoenix/arize_phoenix_evaluate_rag.ipynb
+++ b/third_party/Phoenix/arize_phoenix_evaluate_rag.ipynb
@@ -78,7 +78,7 @@
     "import pandas as pd\n",
     "import phoenix as px\n",
     "from phoenix.otel import register\n",
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
     "\n",
     "import nest_asyncio\n",

--- a/third_party/Phoenix/arize_phoenix_tracing.ipynb
+++ b/third_party/Phoenix/arize_phoenix_tracing.ipynb
@@ -73,8 +73,8 @@
     "import pandas as pd\n",
     "import phoenix as px\n",
     "from phoenix.otel import register\n",
-    "from mistralai import Mistral\n",
-    "from mistralai.models import UserMessage, SystemMessage\n",
+    "from mistralai.client import Mistral\n",
+    "from mistralai.client.models import UserMessage, SystemMessage\n",
     "from openinference.instrumentation.mistralai import MistralAIInstrumentor\n",
     "\n",
     "pd.set_option(\"display.max_colwidth\", None)"

--- a/third_party/Pinecone/pinecone_rag.ipynb
+++ b/third_party/Pinecone/pinecone_rag.ipynb
@@ -227,7 +227,7 @@
       "outputs": [],
       "source": [
         "import os\n",
-        "from mistralai import Mistral\n",
+        "from mistralai.client import Mistral\n",
         "import getpass  # console.mistral.ai/api-keys/\n",
         "\n",
         "# get API key from left navbar in Mistral console\n",

--- a/third_party/gradio/MistralOCR.md
+++ b/third_party/gradio/MistralOCR.md
@@ -1,6 +1,6 @@
 # Building Gradio app with Mistral OCR to extract text and images from PDFs
 
-This cookbook provides a step-by-step guide to setting up and using Mistral OCR with Gradio.  
+This cookbook provides a step-by-step guide to setting up and using Mistral OCR with Gradio.
 The application allows you to extract text and images from PDFs and images using Mistral's OCR capabilities.
 
 ## Prerequisites
@@ -21,7 +21,7 @@ pip install gradio requests mistralai
 
 ## Step 2: Set Up Environment Variables
 
-You need to set up your Mistral API key as an environment variable.  
+You need to set up your Mistral API key as an environment variable.
 You can do this in your terminal or add it to your script.
 
 You can create an API key on our [Platforme](https://console.mistral.ai/api-keys/).
@@ -41,7 +41,7 @@ import gradio as gr
 import os
 import base64
 import requests
-from mistralai import Mistral
+from mistralai.client import Mistral
 ```
 
 ## Step 4: Initialize Mistral Client
@@ -57,7 +57,7 @@ client = Mistral(api_key=api_key)
 
 ### Encode Image to Base64
 
-This function encodes an image to a base64 string.  
+This function encodes an image to a base64 string.
 It will be required to provide local images to the service.
 
 ```python
@@ -74,7 +74,7 @@ def encode_image(image_path):
 
 ### Replace Images in Markdown
 
-This function replaces image placeholders in markdown with base64-encoded images.  
+This function replaces image placeholders in markdown with base64-encoded images.
 Mistral OCR is capable of outputting interleaved text and images; this function will replace placeholders to render with Gradio.
 
 ```python
@@ -86,7 +86,7 @@ def replace_images_in_markdown(markdown_str: str, images_dict: dict) -> str:
 
 ### Get Combined Markdown
 
-This function combines the markdown from all pages of the OCR response.  
+This function combines the markdown from all pages of the OCR response.
 It will output a ready-to-be-rendered version and a raw markdown output without the images.
 
 ```python
@@ -104,7 +104,7 @@ def get_combined_markdown(ocr_response) -> tuple:
 
 ### Fetch Content Type
 
-This function fetches the content type of a URL.  
+This function fetches the content type of a URL.
 The objective is to detect if we are handling PDF files or image files.
 
 ```python
@@ -164,7 +164,7 @@ def perform_ocr_file(file, ocr_method="Mistral OCR"):
 
 ### Perform OCR on URL
 
-Next, we can define a function to perform OCR on URLs.  
+Next, we can define a function to perform OCR on URLs.
 We need different ones for images and for PDF documents.
 
 ```python

--- a/third_party/openlit/cookbook_mistral_opentelemetry.ipynb
+++ b/third_party/openlit/cookbook_mistral_opentelemetry.ipynb
@@ -170,7 +170,7 @@
    "outputs": [],
    "source": [
     "# Synchronous Example\n",
-    "from mistralai import Mistral\n",
+    "from mistralai.client import Mistral\n",
     "import os\n",
     "\n",
     "client = Mistral(\n",

--- a/third_party/solara/README.md
+++ b/third_party/solara/README.md
@@ -16,7 +16,7 @@ pip install solara mistralai
 
 ```py
 import solara as sl
-from mistralai import Mistral
+from mistralai.client import Mistral
 ```
 
 Create your `client` using your Mistral API key.
@@ -105,7 +105,7 @@ To run this code, enter `solara run chat.py` in the console. Alternatively, you 
 
 ```py
 import solara as sl
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 mistral_api_key = "your_api_key"
 client = Mistral(api_key=mistral_api_key)
@@ -174,7 +174,7 @@ This demo uses `PyPDF2===3.0.1` and `faiss-cpu===1.8.0`
 ```py
 import io
 import solara as sl
-from mistralai import Mistral
+from mistralai.client import Mistral
 import numpy as np
 import PyPDF2
 import faiss
@@ -275,7 +275,7 @@ And everything is done! Now we can run our new interface with `solara run chat_w
 ```py
 import io
 import solara as sl
-from mistralai import Mistral
+from mistralai.client import Mistral
 import numpy as np
 import PyPDF2
 import faiss
@@ -319,7 +319,7 @@ messages: sl.Reactive[List[MessageDict]] = sl.reactive([])
 
 def response_generator(messages: list, txt: List[str]):
     response = client.chat.stream(
-        model = "open-mistral-7b", 
+        model = "open-mistral-7b",
         messages = messages[:-1] + [{"role":"user","content": rag_pdf(txt, messages[-1]["content"]) + "\n\n" + messages[-1]["content"]}],
         max_tokens = 1024
     )

--- a/third_party/solara/chat.py
+++ b/third_party/solara/chat.py
@@ -1,5 +1,5 @@
 import solara as sl
-from mistralai import Mistral
+from mistralai.client import Mistral
 
 mistral_api_key = "your_api_key"
 client = Mistral(api_key=mistral_api_key)

--- a/third_party/solara/chat_with_pdfs.py
+++ b/third_party/solara/chat_with_pdfs.py
@@ -1,6 +1,6 @@
 import io
 import solara as sl
-from mistralai import Mistral
+from mistralai.client import Mistral
 import numpy as np
 import PyPDF2
 import faiss
@@ -44,7 +44,7 @@ messages: sl.Reactive[List[MessageDict]] = sl.reactive([])
 
 def response_generator(messages: list, txt: List[str]):
     response = client.chat.stream(
-        model = "open-mistral-7b", 
+        model = "open-mistral-7b",
         messages = messages[:-1] + [{"role":"user","content": rag_pdf(txt, messages[-1]["content"]) + "\n\n" + messages[-1]["content"]}],
         max_tokens = 1024
     )


### PR DESCRIPTION
## Description

This PR globally updates the Python SDK imports across the cookbook to align with the recent Mistral `v2.x` release :) 

Currently, many notebooks and scripts use the `v1.x` import structure (e.g., `from mistralai import Mistral`), which throws an `ImportError` for users installing the latest version of the `mistralai` package. This PR migrates all relevant imports to the new nested `.client` structure as outlined in the official Mistral Migration Guide.

**Changes made:**
* `from mistralai import Mistral` $\rightarrow$ `from mistralai.client import Mistral`
* `from mistralai.models import` $\rightarrow$ `from mistralai.client.models import`
* `from mistralai.types import` $\rightarrow$ `from mistralai.client.types import`
* `from mistralai.utils import` $\rightarrow$ `from mistralai.client.utils import`

No API keys are included in these changes.

## Type of Change
- Cookbook Update
- Code Refactoring
- Bug Fix

## Additional Context

These changes directly follow the official guidelines published in the `mistralai/client-python` repository here: 
**[[MIGRATION.md (v2.0.0)](https://github.com/mistralai/client-python/blob/main/MIGRATION.md)](https://github.com/mistralai/client-python/blob/main/MIGRATION.md)**