### PR TITLE
Fix: update required python version

### DIFF
--- a/mistral/agents/agents_api/multi_agents_data_analysis/pyproject.toml
+++ b/mistral/agents/agents_api/multi_agents_data_analysis/pyproject.toml
@@ -3,7 +3,7 @@ name = "data-analysis-agent"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.13, <3.14"
 dependencies = [
     "authlib>=1.6.0",
     "chainlit>=2.5.5",


### PR DESCRIPTION
### Description
This PR restricts the required Python version to `< 3.14` to ensure compatibility with native dependencies like `orjson` and `langgraph`.

Currently, `uv sync` fails on Python 3.14 (experimental) because the `orjson` build backend (PyO3) does not yet support the 3.14 C-API, causing compilation errors during dependency resolution.

### Changes made:
- **`pyproject.toml`**: Updated `requires-python` from `>=3.13` to `">=3.13, <3.14"`.

### Type of Change
- [x] Bug Fix
- [x] Dependency Management

### Additional Context
`orjson` (v3.10.18) was included because `data-analysis-agent` (v0.1.0) depends on `langgraph` (v0.5.0) which depends on `langgraph-sdk` (v0.1.72) which depends on `orjson`. 

```bash
error: the configured Python interpreter version (3.14) is newer than PyO3 s maximum supported version (3.13)
        = help: please check if an updated version of PyO3 is available. Current version: 0.23.3
        = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI

```
      
