### PR TITLE
Add notebook: visualizing reasoning traces from Mistral models

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [sts_demo.py](mistral/tts/sts_demo.py) | chat, tts | STT -> LLM -> TTS Demo. |
 | [llm_judge_campaign_workflow.ipynb](mistral/observability/llm_judge_campaign_workflow.ipynb) | observability, evaluation | Run campaigns with LLM judges to classify agent behaviors at scale |
 | [manage_datasets.ipynb](mistral/observability/manage_datasets.ipynb) | observability, datasets | Create and manage datasets for evaluation or fine-tuning |
-
+| [visualizing_reasoning_traces.ipynb](mistral/reasoning/visualizing_reasoning_traces.ipynb) | reasoning, visualization | Turn Mistral reasoning traces into structured graphs with typed steps and dependencies |
 
 
 ## Third Party Tools

--- a/mistral/reasoning/visualizing_reasoning_traces.ipynb
+++ b/mistral/reasoning/visualizing_reasoning_traces.ipynb
@@ -1,0 +1,784 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "md-0",
+      "metadata": {
+        "id": "md-0"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/mistralai/cookbook/blob/main/mistral/reasoning/visualizing_reasoning_traces.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+        "\n",
+        "# Visualizing Reasoning Traces from Mistral Models\n",
+        "\n",
+        "_Authored by: Côme Rossary, Stanford University ([@comersy](https://github.com/comersy))_"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-1",
+      "metadata": {
+        "id": "md-1"
+      },
+      "source": [
+        "In this tutorial, you will learn how to turn a model's chain-of-thought into a structured, visual representation that is easy to read and audit."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-2",
+      "metadata": {
+        "id": "md-2"
+      },
+      "source": [
+        "When a reasoning model thinks through a problem, its trace is often long, free-form, and hard to follow. The trace contains hypotheses, deductions, verifications, and sometimes backtracks — but presented as plain text, this structure is invisible."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-3",
+      "metadata": {
+        "id": "md-3"
+      },
+      "source": [
+        "> Mistral offers two ways to obtain reasoning traces: **native reasoning models** ([Magistral](https://docs.mistral.ai/capabilities/reasoning/native)) which always expose their thinking in a dedicated field, and **adjustable reasoning** ([`mistral-small-latest`](https://docs.mistral.ai/capabilities/reasoning/adjustable)) which lets you control reasoning per request via `reasoning_effort`. This notebook uses the latter — available on the free tier — and prompts the model to label each reasoning step explicitly."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-4",
+      "metadata": {
+        "id": "md-4"
+      },
+      "source": [
+        "We will follow these steps:\n",
+        "\n",
+        "* Generate a reasoning trace by asking `mistral-small-latest` with `reasoning_effort='high'` to think step by step.\n",
+        "* Extract the structure from the trace by calling the model again to return a JSON array of typed steps with dependencies.\n",
+        "* Visualize the result as a table and an interactive graph.\n",
+        "\n",
+        "We run the full pipeline on three problems: a **math** problem, a **code** problem, and an **abstract** reasoning problem."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-5",
+      "metadata": {
+        "id": "md-5"
+      },
+      "source": [
+        "## Getting Started"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-6",
+      "metadata": {
+        "id": "md-6"
+      },
+      "source": [
+        "We will install [`pyvis`](https://pyvis.readthedocs.io), a Python wrapper around `vis.js` that renders interactive network graphs in notebooks. Everything else (`requests`, `matplotlib`) is already available in Colab."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-7",
+      "metadata": {
+        "id": "code-7"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install pyvis -q"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-8",
+      "metadata": {
+        "id": "md-8"
+      },
+      "source": [
+        "Now we import the dependencies and set up the API client. We use the Mistral REST API directly via `requests` — `reasoning_effort` is supported as a top-level parameter on the chat completions endpoint."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-9",
+      "metadata": {
+        "id": "md-9"
+      },
+      "source": [
+        "> Get your free API key at [console.mistral.ai](https://console.mistral.ai/api-keys/). In Colab, open the **Secrets** panel (the key icon on the left sidebar) and add a secret named `MISTRAL_API_KEY`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-10",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "code-10",
+        "outputId": "18269fee-acae-4080-e3c4-fa71d2938e11"
+      },
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import re\n",
+        "import json\n",
+        "import time\n",
+        "import requests\n",
+        "import matplotlib.pyplot as plt\n",
+        "import matplotlib.patches as mpatches\n",
+        "import matplotlib.patheffects as pe\n",
+        "import networkx as nx\n",
+        "from pyvis.network import Network\n",
+        "from IPython.display import HTML, display\n",
+        "\n",
+        "# In Colab: open Secrets panel (key icon, left sidebar)\n",
+        "# and add a secret named MISTRAL_API_KEY\n",
+        "try:\n",
+        "    from google.colab import userdata\n",
+        "    api_key = userdata.get('MISTRAL_API_KEY')\n",
+        "except Exception:\n",
+        "    api_key = os.environ.get('MISTRAL_API_KEY')\n",
+        "\n",
+        "if not api_key:\n",
+        "    raise ValueError('MISTRAL_API_KEY not found.')\n",
+        "\n",
+        "API_URL = 'https://api.mistral.ai/v1/chat/completions'\n",
+        "HEADERS  = {\n",
+        "    'Authorization': f'Bearer {api_key}',\n",
+        "    'Content-Type':  'application/json',\n",
+        "}\n",
+        "\n",
+        "print('Ready.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-11",
+      "metadata": {
+        "id": "md-11"
+      },
+      "source": [
+        "## Building the pipeline"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-12",
+      "metadata": {
+        "id": "md-12"
+      },
+      "source": [
+        "The pipeline has three pieces:\n",
+        "\n",
+        "* `call_and_reason(problem)` — calls `mistral-small-latest` with `reasoning_effort='high'` and a system prompt that asks the model to label each step.\n",
+        "* `extract_steps(trace)` — calls the model again with a JSON extraction prompt, returning a list of typed steps with their dependencies.\n",
+        "* `print_steps(steps)` and `draw_graph(steps)` — render the structured output as an HTML table and an interactive `pyvis` graph."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-13",
+      "metadata": {
+        "id": "md-13"
+      },
+      "source": [
+        "Each reasoning step is classified as one of six types: **observation**, **hypothesis**, **deduction**, **verification**, **backtrack**, or **conclusion**. This taxonomy lets us color and connect the steps in the visualization."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-14",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "code-14",
+        "outputId": "01c75ae4-4e45-4786-f2ea-e664fdc830ca"
+      },
+      "outputs": [],
+      "source": [
+        "import re\n",
+        "import json\n",
+        "from IPython.display import HTML, display\n",
+        "\n",
+        "# ── Prompts ───────────────────────────────────────────────────\n",
+        "\n",
+        "REASONING_SYSTEM_PROMPT = \"\"\"You are a careful reasoner. When given a problem, think through it step by step.\n",
+        "Format your reasoning as a numbered list where each step starts with its type in brackets:\n",
+        "[observation], [hypothesis], [deduction], [verification], [backtrack], or [conclusion].\n",
+        "\n",
+        "Example format:\n",
+        "1. [observation] The function returns `a` instead of `b` at the end.\n",
+        "2. [hypothesis] The loop may be running one iteration short.\n",
+        "3. [deduction] For n=1, range(0) runs 0 times, so a stays 0 instead of becoming 1.\n",
+        "4. [conclusion] The fix is to return `b` instead of `a`.\n",
+        "\n",
+        "After the reasoning steps, provide a clear final answer separated by a line '---'.\"\"\"\n",
+        "\n",
+        "EXTRACTION_PROMPT = \"\"\"You are given a reasoning trace formatted as a numbered list.\n",
+        "Extract each step and return a JSON array.\n",
+        "\n",
+        "Each object must have:\n",
+        "- \"id\": integer (step number)\n",
+        "- \"type\": one of observation/hypothesis/deduction/verification/backtrack/conclusion\n",
+        "- \"summary\": one sentence, max 20 words\n",
+        "- \"depends_on\": list of step ids this step follows from (empty if it's a starting step)\n",
+        "\n",
+        "Return ONLY valid JSON. No explanation, no markdown fences.\n",
+        "\n",
+        "Reasoning trace:\n",
+        "{trace}\n",
+        "\"\"\"\n",
+        "\n",
+        "# ── API calls ─────────────────────────────────────────────────\n",
+        "\n",
+        "def call_and_reason(problem):\n",
+        "    resp = requests.post(API_URL, headers=HEADERS, json={\n",
+        "        'model':            'mistral-small-latest',\n",
+        "        'reasoning_effort': 'high',\n",
+        "        'messages': [\n",
+        "            {'role': 'system', 'content': REASONING_SYSTEM_PROMPT},\n",
+        "            {'role': 'user',   'content': problem},\n",
+        "        ],\n",
+        "    })\n",
+        "    data = resp.json()\n",
+        "    if 'choices' not in data:\n",
+        "        raise ValueError(data.get('message', data))\n",
+        "\n",
+        "    raw = data['choices'][0]['message']['content']\n",
+        "    if isinstance(raw, list):\n",
+        "        content = ' '.join(c.get('text', '') for c in raw if isinstance(c, dict))\n",
+        "    else:\n",
+        "        content = raw\n",
+        "\n",
+        "    parts = content.split('---', 1)\n",
+        "    return {\n",
+        "        'trace':  parts[0].strip(),\n",
+        "        'answer': parts[1].strip() if len(parts) > 1 else '',\n",
+        "        'usage':  data['usage'],\n",
+        "    }\n",
+        "\n",
+        "\n",
+        "def extract_steps(trace):\n",
+        "    prompt = EXTRACTION_PROMPT.format(trace=trace[:6000])\n",
+        "    resp = requests.post(API_URL, headers=HEADERS, json={\n",
+        "        'model':    'mistral-small-latest',\n",
+        "        'messages': [{'role': 'user', 'content': prompt}],\n",
+        "    })\n",
+        "    data = resp.json()\n",
+        "    if 'choices' not in data:\n",
+        "        raise ValueError(data.get('message', data))\n",
+        "    raw = data['choices'][0]['message']['content']\n",
+        "    raw = re.sub(r'```json|```', '', raw).strip()\n",
+        "    return json.loads(raw)\n",
+        "\n",
+        "\n",
+        "# ── Visualization: Cytoscape.js interactive graph ─────────────\n",
+        "\n",
+        "TYPE_COLORS = {\n",
+        "    'observation':  '#3498db',\n",
+        "    'hypothesis':   '#2ecc71',\n",
+        "    'deduction':    '#f1c40f',\n",
+        "    'verification': '#e67e22',\n",
+        "    'backtrack':    '#e74c3c',\n",
+        "    'conclusion':   '#9b59b6',\n",
+        "}\n",
+        "\n",
+        "def print_steps(steps):\n",
+        "    \"\"\"Display steps as a clean HTML table.\"\"\"\n",
+        "    rows = ''\n",
+        "    for s in steps:\n",
+        "        color = TYPE_COLORS.get(s['type'], '#95a5a6')\n",
+        "        deps  = ', '.join(str(d) for d in s.get('depends_on', [])) or '—'\n",
+        "        rows += f\"\"\"\n",
+        "        <tr>\n",
+        "          <td style=\"padding:10px 14px;border-bottom:1px solid #eee;font-weight:600;color:#333\">{s['id']}</td>\n",
+        "          <td style=\"padding:10px 14px;border-bottom:1px solid #eee\">\n",
+        "            <span style=\"background:{color};color:white;padding:3px 10px;border-radius:12px;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.3px\">{s['type']}</span>\n",
+        "          </td>\n",
+        "          <td style=\"padding:10px 14px;border-bottom:1px solid #eee;color:#666;font-size:13px\">{deps}</td>\n",
+        "          <td style=\"padding:10px 14px;border-bottom:1px solid #eee;color:#222\">{s['summary']}</td>\n",
+        "        </tr>\"\"\"\n",
+        "\n",
+        "    html = f\"\"\"\n",
+        "    <div style=\"font-family:-apple-system,sans-serif;margin:16px 0\">\n",
+        "      <table style=\"border-collapse:collapse;width:100%;background:white;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.08)\">\n",
+        "        <thead>\n",
+        "          <tr style=\"background:#2c3e50;color:white\">\n",
+        "            <th style=\"padding:12px 14px;text-align:left;font-weight:600;font-size:13px\">#</th>\n",
+        "            <th style=\"padding:12px 14px;text-align:left;font-weight:600;font-size:13px\">Type</th>\n",
+        "            <th style=\"padding:12px 14px;text-align:left;font-weight:600;font-size:13px\">Depends on</th>\n",
+        "            <th style=\"padding:12px 14px;text-align:left;font-weight:600;font-size:13px\">Summary</th>\n",
+        "          </tr>\n",
+        "        </thead>\n",
+        "        <tbody>{rows}</tbody>\n",
+        "      </table>\n",
+        "    </div>\"\"\"\n",
+        "    display(HTML(html))\n",
+        "\n",
+        "def draw_graph(steps, title='Reasoning Graph'):\n",
+        "    if not steps:\n",
+        "        print('No steps to draw.')\n",
+        "        return\n",
+        "\n",
+        "    net = Network(\n",
+        "        height='600px',\n",
+        "        width='100%',\n",
+        "        directed=True,\n",
+        "        bgcolor='#fafafa',\n",
+        "        font_color='#222',\n",
+        "        notebook=True,\n",
+        "        cdn_resources='in_line',\n",
+        "    )\n",
+        "\n",
+        "    # Hierarchical layout (top to bottom)\n",
+        "    net.set_options(\"\"\"\n",
+        "    {\n",
+        "      \"layout\": {\n",
+        "        \"hierarchical\": {\n",
+        "          \"enabled\": true,\n",
+        "          \"direction\": \"UD\",\n",
+        "          \"sortMethod\": \"directed\",\n",
+        "          \"levelSeparation\": 130,\n",
+        "          \"nodeSpacing\": 200,\n",
+        "          \"treeSpacing\": 200\n",
+        "        }\n",
+        "      },\n",
+        "      \"physics\": {\n",
+        "        \"enabled\": false\n",
+        "      },\n",
+        "      \"edges\": {\n",
+        "        \"smooth\": {\n",
+        "          \"type\": \"cubicBezier\",\n",
+        "          \"forceDirection\": \"vertical\",\n",
+        "          \"roundness\": 0.4\n",
+        "        },\n",
+        "        \"arrows\": {\n",
+        "          \"to\": {\"enabled\": true, \"scaleFactor\": 0.7}\n",
+        "        },\n",
+        "        \"color\": {\"color\": \"#999\"},\n",
+        "        \"width\": 1.5\n",
+        "      },\n",
+        "      \"nodes\": {\n",
+        "        \"shape\": \"box\",\n",
+        "        \"borderWidth\": 2,\n",
+        "        \"margin\": 12,\n",
+        "        \"font\": {\"size\": 13, \"face\": \"arial\", \"color\": \"#222\"},\n",
+        "        \"widthConstraint\": {\"minimum\": 180, \"maximum\": 220}\n",
+        "      },\n",
+        "      \"interaction\": {\n",
+        "        \"hover\": true,\n",
+        "        \"dragNodes\": true,\n",
+        "        \"zoomView\": true\n",
+        "      }\n",
+        "    }\n",
+        "    \"\"\")\n",
+        "\n",
+        "    # Add nodes\n",
+        "    for s in steps:\n",
+        "        color = TYPE_COLORS.get(s['type'], '#95a5a6')\n",
+        "        label = f\"#{s['id']}  {s['type'].upper()}\\n\\n{s['summary']}\"\n",
+        "        title_html = f\"<b>{s['type'].upper()}</b><br>{s['summary']}\"\n",
+        "        net.add_node(\n",
+        "            s['id'],\n",
+        "            label=label,\n",
+        "            title=title_html,\n",
+        "            color={\n",
+        "                'background': color + '33',  # transparent fill\n",
+        "                'border': color,\n",
+        "                'highlight': {'background': color + '55', 'border': '#222'},\n",
+        "            },\n",
+        "            font={'color': '#222', 'size': 12},\n",
+        "        )\n",
+        "\n",
+        "    # Add edges\n",
+        "    for s in steps:\n",
+        "        for dep in s.get('depends_on', []):\n",
+        "            is_back = dep > s['id']\n",
+        "            net.add_edge(\n",
+        "                dep, s['id'],\n",
+        "                color={'color': '#e74c3c' if is_back else '#999'},\n",
+        "                dashes=is_back,\n",
+        "            )\n",
+        "\n",
+        "    # Legend HTML\n",
+        "    legend_html = '<div style=\"margin:12px 0;display:flex;gap:14px;flex-wrap:wrap;font-family:-apple-system,sans-serif;font-size:12px\">'\n",
+        "    for t, c in TYPE_COLORS.items():\n",
+        "        legend_html += f'<div style=\"display:flex;align-items:center;gap:6px\"><span style=\"width:14px;height:14px;background:{c};border-radius:3px;border:1px solid #ccc\"></span><span style=\"color:#555\">{t}</span></div>'\n",
+        "    legend_html += '</div>'\n",
+        "\n",
+        "    # Render\n",
+        "    html = net.generate_html(notebook=True)\n",
+        "    full = f'<div style=\"font-family:-apple-system,sans-serif;margin:16px 0\"><div style=\"font-size:15px;font-weight:600;color:#222;margin-bottom:8px\">{title}</div>{legend_html}{html}</div>'\n",
+        "    display(HTML(full))\n",
+        "\n",
+        "\n",
+        "print('Helpers defined.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-15",
+      "metadata": {
+        "id": "md-15"
+      },
+      "source": [
+        "## Math problem — Bayesian probability"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-16",
+      "metadata": {
+        "id": "md-16"
+      },
+      "source": [
+        "We start with a classic Bayesian probability question that requires setting up the theorem, computing intermediate probabilities, and applying the formula. A reasoning model should produce a chain of observations and deductions leading to a clean conclusion."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-17",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "code-17",
+        "outputId": "a1456267-90c4-48a0-ff6d-a9f5a2dcdde6"
+      },
+      "outputs": [],
+      "source": [
+        "MATH_PROBLEM = \"\"\"\n",
+        "A company has 3 servers. Server A handles 50% of requests, B handles 30%, C handles 20%.\n",
+        "Error rates: A=2%, B=5%, C=10%.\n",
+        "A request fails. What is the probability it came from Server C?\n",
+        "\"\"\"\n",
+        "\n",
+        "print('Step 1: Generating reasoning trace...')\n",
+        "math_result = call_and_reason(MATH_PROBLEM)\n",
+        "print(f\"Done. {math_result['usage']['completion_tokens']} tokens.\\n\")\n",
+        "print('=== REASONING TRACE ===')\n",
+        "print(math_result['trace'])\n",
+        "print('\\n=== FINAL ANSWER ===')\n",
+        "print(math_result['answer'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-18",
+      "metadata": {
+        "id": "md-18"
+      },
+      "source": [
+        "Once we have the trace, we extract its structure. The extraction call returns a JSON array — each item is one step with its type, summary, and list of step ids it depends on."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-19",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 372
+        },
+        "id": "code-19",
+        "outputId": "50ff0ed5-b2d9-43a9-e2f5-547714a085f0"
+      },
+      "outputs": [],
+      "source": [
+        "print('Step 2: Extracting structured steps...')\n",
+        "math_steps = extract_steps(math_result['trace'])\n",
+        "print(f'{len(math_steps)} steps extracted.\\n')\n",
+        "print_steps(math_steps)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-20",
+      "metadata": {
+        "id": "md-20"
+      },
+      "source": [
+        "Now we visualize the reasoning as a directed graph. Nodes are colored by step type, edges show logical dependencies. The graph is interactive — drag nodes to rearrange, scroll to zoom, hover for details."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-21",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 740
+        },
+        "id": "code-21",
+        "outputId": "06c392e2-7d5f-4b53-eb11-99c7720f1317"
+      },
+      "outputs": [],
+      "source": [
+        "print('Step 3: Drawing reasoning graph...')\n",
+        "draw_graph(math_steps, title='Reasoning Graph — Bayesian Probability')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-22",
+      "metadata": {
+        "id": "md-22"
+      },
+      "source": [
+        "## Code problem — Bug detection"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-23",
+      "metadata": {
+        "id": "md-23"
+      },
+      "source": [
+        "Next, a Python function with a subtle off-by-one bug. This kind of problem benefits from step-by-step tracing: the model needs to walk through what the code actually does on small inputs and identify where the output diverges from the expected behavior."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-24",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "code-24",
+        "outputId": "40539bfc-fb9e-450d-ffb6-466e9d81e171"
+      },
+      "outputs": [],
+      "source": [
+        "CODE_PROBLEM = \"\"\"\n",
+        "Find and fix the bug in this Python function:\n",
+        "\n",
+        "```python\n",
+        "def fibonacci(n):\n",
+        "    if n <= 0:\n",
+        "        return 0\n",
+        "    a, b = 0, 1\n",
+        "    for _ in range(n - 1):\n",
+        "        a, b = b, a + b\n",
+        "    return a\n",
+        "```\n",
+        "\n",
+        "Expected: fibonacci(1)=1, fibonacci(6)=8, fibonacci(10)=55\n",
+        "\"\"\"\n",
+        "\n",
+        "print('Step 1: Generating reasoning trace...')\n",
+        "code_result = call_and_reason(CODE_PROBLEM)\n",
+        "print(f\"Done. {code_result['usage']['completion_tokens']} tokens.\\n\")\n",
+        "print('=== REASONING TRACE ===')\n",
+        "print(code_result['trace'])\n",
+        "print('\\n=== FINAL ANSWER ===')\n",
+        "print(code_result['answer'])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-25",
+      "metadata": {
+        "id": "md-25"
+      },
+      "source": [
+        "Same extraction step — we ask the model to surface the structure of its own reasoning."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-26",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 411
+        },
+        "id": "code-26",
+        "outputId": "a6d6df11-9fc7-49be-d619-ca6d2eaaef04"
+      },
+      "outputs": [],
+      "source": [
+        "print('Step 2: Extracting structured steps...')\n",
+        "code_steps = extract_steps(code_result['trace'])\n",
+        "print(f'{len(code_steps)} steps extracted.\\n')\n",
+        "print_steps(code_steps)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-27",
+      "metadata": {
+        "id": "md-27"
+      },
+      "source": [
+        "Bug-detection reasoning typically has a clear linear shape: observe the symptom, hypothesize the cause, trace through the failing case, verify, and propose a fix. The graph makes this trajectory visible."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-28",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 740
+        },
+        "id": "code-28",
+        "outputId": "a81bde57-5243-42a1-d94d-137b7221e622"
+      },
+      "outputs": [],
+      "source": [
+        "print('Step 3: Drawing reasoning graph...')\n",
+        "draw_graph(code_steps, title='Reasoning Graph — Bug Detection')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-29",
+      "metadata": {
+        "id": "md-29"
+      },
+      "source": [
+        "## Abstract problem — Open-ended reasoning"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-30",
+      "metadata": {
+        "id": "md-30"
+      },
+      "source": [
+        "Finally, a conceptual question with no single correct answer. Abstract problems push the model into a different reasoning mode: instead of applying a formula or tracing code, it must weigh arguments, draw on multiple frames, and synthesize a position."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-31",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "code-31",
+        "outputId": "784f446a-3230-4fe7-cb93-833fdc6d7705"
+      },
+      "outputs": [],
+      "source": [
+        "ABSTRACT_PROBLEM = \"\"\"\n",
+        "Why does trust take a long time to build but can be destroyed in an instant?\n",
+        "\"\"\"\n",
+        "\n",
+        "print('Step 1: Generating reasoning trace...')\n",
+        "abstract_result = call_and_reason(ABSTRACT_PROBLEM)\n",
+        "print(f\"Done. {abstract_result['usage']['completion_tokens']} tokens.\\n\")\n",
+        "print('=== REASONING TRACE ===')\n",
+        "print(abstract_result['trace'])\n",
+        "print('\\n=== FINAL ANSWER ===')\n",
+        "print(abstract_result['answer'])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-32",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 527
+        },
+        "id": "code-32",
+        "outputId": "78c6b50f-2e17-475b-96e2-187051407e62"
+      },
+      "outputs": [],
+      "source": [
+        "print('Step 2: Extracting structured steps...')\n",
+        "abstract_steps = extract_steps(abstract_result['trace'])\n",
+        "print(f'{len(abstract_steps)} steps extracted.\\n')\n",
+        "print_steps(abstract_steps)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-33",
+      "metadata": {
+        "id": "md-33"
+      },
+      "source": [
+        "Abstract reasoning often produces wider, more branching graphs than math or code — multiple parallel hypotheses converge into a single conclusion. This is where the visualization is most useful, since the structure is genuinely hard to follow as plain text."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "code-34",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 740
+        },
+        "id": "code-34",
+        "outputId": "934f56e4-71e8-42e7-b73b-47ab92617ee8"
+      },
+      "outputs": [],
+      "source": [
+        "print('Step 3: Drawing reasoning graph...')\n",
+        "draw_graph(abstract_steps, title='Reasoning Graph — Abstract Problem')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-35",
+      "metadata": {
+        "id": "md-35"
+      },
+      "source": [
+        "## Next steps"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "md-36",
+      "metadata": {
+        "id": "md-36"
+      },
+      "source": [
+        "You now have a reusable pipeline to turn any model reasoning into a structured graph. A few directions to explore from here:\n",
+        "\n",
+        "* Swap in [Magistral](https://docs.mistral.ai/capabilities/reasoning/native) (`magistral-small-latest` or `magistral-medium-latest`) to work with native thinking traces instead of prompted ones — Magistral returns its reasoning in a dedicated `thinking` field without needing the labeling system prompt.\n",
+        "* Add custom step types (e.g. `assumption`, `counter-example`) by editing the system prompt and the color map.\n",
+        "* Export graphs as standalone HTML with `net.save_graph('graph.html')` to share auditable reasoning traces outside the notebook.\n",
+        "* Run the pipeline on a batch of problems and compare graph topology (depth, branching factor) across problem types as a proxy for reasoning complexity."
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## What this notebook does

This notebook turns a model's chain-of-thought into a structured, visual representation. The pipeline asks `mistral-small-latest` (with `reasoning_effort='high'`) to label each reasoning step by type, then makes a second model call to extract the structure as JSON, and finally renders the result as an interactive `pyvis` graph and an HTML table. The full pipeline is demonstrated on three problems: a Bayesian probability question, a Python bug-detection task, and an open-ended abstract reasoning question.

## Runs on free tier

The notebook uses `mistral-small-latest` with `reasoning_effort='high'`, both available on the Mistral free tier. No GPU required — it runs end-to-end on Colab CPU with only a free Mistral API key. The notebook explicitly references [Magistral](https://docs.mistral.ai/capabilities/reasoning/native) as an alternative for users with paid access who want native thinking traces.

## Submission guidelines checklist

- [x] **File format**: `.ipynb`
- [x] **Runnable on Colab**: tested end-to-end on a fresh Colab runtime
- [x] **Authorship**: name, GitHub handle, and affiliation included at the top of the notebook
- [x] **Description**: added to the README under Main Notebooks with category `reasoning, visualization`
- [x] **Tone**: neutral, no marketing
- [x] **Reproducibility**: `pyvis` pinned via the standard install cell; all other dependencies are pre-installed in Colab
- [x] **Image size**: no static images included
- [x] **Copyright**: all content is original