### PR TITLE
feat: add TWZRD Agent Intel MCP agent trust verification example

### DIFF
--- a/third_party/TWZRD/README.md
+++ b/third_party/TWZRD/README.md
@@ -1,0 +1,60 @@
+# TWZRD Agent Intel + Mistral
+
+This example shows how to use [TWZRD Agent Intel](https://intel.twzrd.xyz) with
+Mistral models to verify the trustworthiness of autonomous AI agents before
+routing value through an [x402](https://x402.org) payment workflow.
+
+TWZRD scores agents (0–100) based on their on-chain Solana transaction history.
+Agents with repeated, consistent payment behavior score higher. The score is
+returned via a free MCP server at `https://intel.twzrd.xyz/mcp`.
+
+## What it demonstrates
+
+- Connecting to a remote MCP server (streamable-http) from a Python script
+- Using `score_agent` to evaluate an agent wallet before transacting
+- Using `preflight_check` to surface context about an unknown agent
+
+## Requirements
+
+```shell
+pip install mistralai mcp
+```
+
+No API key is required for the TWZRD tools. You will need a Mistral API key:
+
+```shell
+export MISTRAL_API_KEY=your_key_here
+```
+
+## Run
+
+```shell
+python agent_trust_check.py
+```
+
+## MCP server config
+
+```json
+{
+  "mcpServers": {
+    "twzrd-agent-intel": {
+      "url": "https://intel.twzrd.xyz/mcp"
+    }
+  }
+}
+```
+
+## Available free tools
+
+| Tool | Description |
+|------|-------------|
+| `score_agent` | On-chain trust score (0–100) for a Solana wallet |
+| `resolve_agent` | Resolve a handle / domain to a wallet address |
+| `preflight_check` | Human-readable context before sending a payment |
+| `verify_trust_receipt` | Verify a signed receipt from a paid `get_trust_receipt` call |
+
+## Resources
+
+- MCP endpoint: `https://intel.twzrd.xyz/mcp`
+- PyPI: `pip install twzrd-agent-intel`
+- Docs: [https://intel.twzrd.xyz](https://intel.twzrd.xyz)

--- a/third_party/TWZRD/agent_trust_check.py
+++ b/third_party/TWZRD/agent_trust_check.py
@@ -1,0 +1,65 @@
+"""
+TWZRD Agent Intel + Mistral — agent trust verification before x402 transactions.
+
+Uses the TWZRD Agent Intel MCP server (https://intel.twzrd.xyz/mcp) to score
+an AI agent's on-chain reputation, then feeds the result to Mistral to
+generate a plain-language recommendation.
+
+Install: pip install mistralai mcp
+"""
+
+import asyncio
+import json
+import os
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mistralai import Mistral
+
+
+MCP_URL = "https://intel.twzrd.xyz/mcp"
+MISTRAL_MODEL = "mistral-small-latest"
+
+
+async def score_agent(wallet: str) -> dict:
+    """Call score_agent on the TWZRD MCP server and return the raw result."""
+    async with streamablehttp_client(MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool("score_agent", {"wallet": wallet})
+            return json.loads(result.content[0].text)
+
+
+def interpret_score(wallet: str, score_data: dict) -> str:
+    """Ask Mistral to explain the trust score in plain language."""
+    client = Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+
+    prompt = (
+        f"An autonomous AI agent with wallet {wallet} has the following trust score data:\n"
+        f"{json.dumps(score_data, indent=2)}\n\n"
+        "Explain what this score means in 2-3 sentences. "
+        "Should a system operator route a payment through this agent? Why or why not?"
+    )
+
+    response = client.chat.complete(
+        model=MISTRAL_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content
+
+
+async def main():
+    # Example: a known active agent on Solana mainnet
+    wallet = "D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi"
+
+    print(f"Checking trust score for {wallet}...")
+    score_data = await score_agent(wallet)
+    print("Raw score data:", json.dumps(score_data, indent=2))
+
+    interpretation = interpret_score(wallet, score_data)
+    print("\nMistral interpretation:")
+    print(interpretation)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds `third_party/TWZRD/` — a working example demonstrating how to use the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server with Mistral to verify the trustworthiness of autonomous AI agents before routing value in an x402 payment workflow.

**Files added:**
- `third_party/TWZRD/README.md` — setup instructions, available tools, and config snippet
- `third_party/TWZRD/agent_trust_check.py` — standalone Python script (asyncio + MCP + Mistral)

## What the example demonstrates

1. Connecting to a remote MCP server (`streamable-http`) from Python using the `mcp` SDK
2. Calling `score_agent` to retrieve an on-chain trust score (0–100) for a Solana wallet
3. Passing the raw score to Mistral (`mistral-small-latest`) for a plain-language recommendation on whether to transact with the agent

## Run it

```bash
pip install mistralai mcp
export MISTRAL_API_KEY=your_key_here
python third_party/TWZRD/agent_trust_check.py
```

No API key is required for the TWZRD tools — they are free via the MCP endpoint at `https://intel.twzrd.xyz/mcp`.

## Why this fits third_party/

- Uses Mistral for the language model (the score interpretation step)
- Integrates an external MCP data source in a way that showcases `mistralai` SDK + MCP interoperability
- Pattern is applicable to any agent payment or trust-gating workflow