### PR TITLE
Add Voxtral TTS cookbook (voice cloning, multilingual, streaming)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [sts_demo.py](mistral/tts/sts_demo.py) | chat, tts | STT -> LLM -> TTS Demo. |
 | [llm_judge_campaign_workflow.ipynb](mistral/observability/llm_judge_campaign_workflow.ipynb) | observability, evaluation | Run campaigns with LLM judges to classify agent behaviors at scale |
 | [manage_datasets.ipynb](mistral/observability/manage_datasets.ipynb) | observability, datasets | Create and manage datasets for evaluation or fine-tuning |
+| [voxtral_tts.ipynb](mistral/tts/voxtral_tts.ipynb) | TTS, voice cloning | Text-to-speech with Voxtral: preset voices, zero-shot voice cloning, cross-lingual transfer, streaming, and a voice-reply agent |
 
 
 

--- a/mistral/tts/voxtral_tts.ipynb
+++ b/mistral/tts/voxtral_tts.ipynb
@@ -1,0 +1,461 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Voice Cloning & Multilingual Speech with Voxtral TTS\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/mistralai/cookbook/blob/main/mistral/tts/voxtral_tts.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>\n",
+    "\n",
+    "**Author:** Utkarsh Kanwat ([@ukanwat](https://github.com/ukanwat)) — Community Contributor\n",
+    "\n",
+    "[Voxtral TTS](https://docs.mistral.ai/studio-api/audio/text_to_speech) is Mistral's text-to-speech model. It turns text into natural, expressive speech, supports nine languages, and can clone a voice from a few seconds of reference audio — all through a single API.\n",
+    "\n",
+    "This notebook is a practical tour of the **text-to-speech** side of the Voxtral family. (Audio *understanding* and transcription are covered separately.) You will:\n",
+    "\n",
+    "1. Generate speech with built-in **preset voices**.\n",
+    "2. **Clone a voice** zero-shot from a short reference clip.\n",
+    "3. Make a voice speak in **other languages** (cross-lingual transfer).\n",
+    "4. Use **streaming** output and compare audio formats and latency.\n",
+    "5. Wire TTS into a small **voice-reply agent** (LLM → speech).\n",
+    "6. *(Appendix)* Run the **open-weights** `Voxtral-4B-TTS` model locally.\n",
+    "\n",
+    "Everything runs against the hosted API with a `MISTRAL_API_KEY`, and the notebook is self-contained — no audio files need to be downloaded.\n",
+    "\n",
+    "| | |\n",
+    "|---|---|\n",
+    "| Model | `voxtral-mini-tts-2603` |\n",
+    "| Endpoint | `/v1/audio/speech` |\n",
+    "| Pricing | ~\\$0.016 / 1k characters |\n",
+    "| Open weights | [`mistralai/Voxtral-4B-TTS-2603`](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) (Apache-2.0) |"
+   ],
+   "id": "cell-0"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Voxtral TTS needs the **`mistralai` 2.x** SDK, which requires **Python ≥ 3.10** (Colab's default runtime is fine). Note the import path: in `mistralai` 2.x the client is imported as `from mistralai.client import Mistral`."
+   ],
+   "id": "cell-1"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"mistralai==2.5.0\""
+   ],
+   "id": "cell-2"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Authentication\n",
+    "\n",
+    "You'll need a `MISTRAL_API_KEY` — get one from the [Mistral console](https://console.mistral.ai/). In Colab, the cleanest option is the **Secrets** panel (🔑 in the left sidebar): add a secret named `MISTRAL_API_KEY` and enable it for this notebook. Never hard-code your key into the notebook."
+   ],
+   "id": "cell-3"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import base64\n",
+    "import time\n",
+    "from pathlib import Path\n",
+    "from getpass import getpass\n",
+    "\n",
+    "api_key = os.environ.get(\"MISTRAL_API_KEY\")\n",
+    "\n",
+    "# Colab Secrets panel\n",
+    "if not api_key:\n",
+    "    try:\n",
+    "        from google.colab import userdata\n",
+    "        api_key = userdata.get(\"MISTRAL_API_KEY\")\n",
+    "    except Exception:\n",
+    "        pass\n",
+    "\n",
+    "# Fallback: secure prompt (input is hidden)\n",
+    "if not api_key:\n",
+    "    api_key = getpass(\"Enter your MISTRAL_API_KEY: \")\n",
+    "\n",
+    "from mistralai.client import Mistral\n",
+    "from IPython.display import Audio, display\n",
+    "\n",
+    "client = Mistral(api_key=api_key)\n",
+    "TTS_MODEL = \"voxtral-mini-tts-2603\""
+   ],
+   "id": "cell-4"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Helpers\n",
+    "\n",
+    "`client.audio.speech.complete` returns the generated audio as base64 in `audio_data`. These two helpers decode it to a file and return an inline player."
+   ],
+   "id": "cell-5"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def synthesize(text, voice_id, response_format=\"mp3\"):\n",
+    "    \"\"\"Generate speech and return the decoded audio bytes.\"\"\"\n",
+    "    response = client.audio.speech.complete(\n",
+    "        model=TTS_MODEL,\n",
+    "        input=text,\n",
+    "        voice_id=voice_id,\n",
+    "        response_format=response_format,\n",
+    "    )\n",
+    "    return base64.b64decode(response.audio_data)\n",
+    "\n",
+    "\n",
+    "def speak(text, voice_id, path, response_format=\"mp3\"):\n",
+    "    \"\"\"Synthesize `text` with `voice_id`, save to `path`, return a player widget.\"\"\"\n",
+    "    Path(path).write_bytes(synthesize(text, voice_id, response_format))\n",
+    "    return Audio(filename=path)"
+   ],
+   "id": "cell-6"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Preset voices\n",
+    "\n",
+    "Voxtral TTS ships with built-in preset voices, so you can generate speech with zero setup. Each preset has a human-readable `slug` (e.g. `gb_jane_neutral`) that you pass as `voice_id`."
+   ],
+   "id": "cell-7"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speak(\n",
+    "    \"Hello! This is Voxtral, Mistral's text-to-speech model, \"\n",
+    "    \"speaking with one of the built-in preset voices.\",\n",
+    "    voice_id=\"gb_jane_neutral\",\n",
+    "    path=\"preset_voice.mp3\",\n",
+    ")"
+   ],
+   "id": "cell-8"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Browse the preset-voice catalogue.\n",
+    "voices = client.audio.voices.list(type_=\"preset\")\n",
+    "print(f\"{voices.total} preset voices available, for example:\")\n",
+    "for v in voices.items[:8]:\n",
+    "    print(f\"  {v.slug:24} {v.name}\")"
+   ],
+   "id": "cell-9"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Zero-shot voice cloning\n",
+    "\n",
+    "Cloning needs a short reference clip — roughly **5–25 seconds** works best (as little as 3s is accepted). To keep this notebook self-contained, we first *synthesize* a reference clip with a preset voice. **In a real application, replace this with an actual recording** of the speaker you want to clone (see the optional upload cell below).\n",
+    "\n",
+    "> **Note:** creating custom (cloned) voices requires an **active paid plan**. Preset voices and everything else in this notebook work on all plans. If cloning isn't available on your account, the cells below automatically fall back to a preset voice so the notebook still runs end to end."
+   ],
+   "id": "cell-10"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reference_path = \"reference.mp3\"\n",
+    "Path(reference_path).write_bytes(\n",
+    "    synthesize(\n",
+    "        \"This is a reference recording. In a real project you would supply a short \"\n",
+    "        \"clip of the voice you want to clone, such as a voice note or a podcast snippet.\",\n",
+    "        voice_id=\"gb_jane_neutral\",\n",
+    "    )\n",
+    ")\n",
+    "Audio(filename=reference_path)"
+   ],
+   "id": "cell-11"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a reusable cloned voice from the reference clip (falls back gracefully).\n",
+    "clone_voice_id = None\n",
+    "try:\n",
+    "    created = client.audio.voices.create(\n",
+    "        name=\"cookbook-cloned-voice\",\n",
+    "        sample_audio=base64.b64encode(Path(reference_path).read_bytes()).decode(),\n",
+    "        sample_filename=reference_path,\n",
+    "        languages=[\"en\"],\n",
+    "    )\n",
+    "    clone_voice_id = created.id\n",
+    "    print(\"Created cloned voice:\", clone_voice_id)\n",
+    "except Exception as e:\n",
+    "    print(\"Voice cloning unavailable (custom voices require an active paid plan):\")\n",
+    "    print(\" \", e)\n",
+    "    print(\"Falling back to a preset voice for the remaining demos.\")\n",
+    "\n",
+    "# Voice used for the cloning + cross-lingual demos below:\n",
+    "# the cloned voice if we have one, otherwise a preset so the notebook still runs.\n",
+    "demo_voice = clone_voice_id or \"gb_jane_neutral\""
+   ],
+   "id": "cell-12"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The demo voice (cloned, or preset fallback) reads text it has never seen.\n",
+    "speak(\n",
+    "    \"And now the voice reads a brand new sentence, in the timbre of the reference clip.\",\n",
+    "    voice_id=demo_voice,\n",
+    "    path=\"demo_voice.mp3\",\n",
+    ")"
+   ],
+   "id": "cell-13"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Clone your own voice (optional, Colab).** Uncomment to upload a 5–25s clip of yourself and hear it read new text."
+   ],
+   "id": "cell-14"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# from google.colab import files\n",
+    "# uploaded = files.upload()  # pick a 5-25s .mp3/.wav recording\n",
+    "# fname = next(iter(uploaded))\n",
+    "# created = client.audio.voices.create(\n",
+    "#     name=\"my-voice\",\n",
+    "#     sample_audio=base64.b64encode(Path(fname).read_bytes()).decode(),\n",
+    "#     sample_filename=fname,\n",
+    "#     languages=[\"en\"],\n",
+    "# )\n",
+    "# speak(\"Hello, this is my own cloned voice.\", voice_id=created.id, path=\"my_voice.mp3\")"
+   ],
+   "id": "cell-15"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Cross-lingual transfer\n",
+    "\n",
+    "A single voice can speak multiple languages. Here the same `demo_voice` (your cloned voice, or the preset fallback) reads the same idea in English, French, Spanish, and Hindi."
+   ],
+   "id": "cell-16"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phrases = {\n",
+    "    \"English\": \"Voxtral can read this text aloud in a natural voice.\",\n",
+    "    \"French\":  \"Voxtral peut lire ce texte à voix haute avec une voix naturelle.\",\n",
+    "    \"Spanish\": \"Voxtral puede leer este texto en voz alta con una voz natural.\",\n",
+    "    \"Hindi\":   \"वोक्सट्राल इस पाठ को एक स्वाभाविक आवाज़ में पढ़ सकता है।\",\n",
+    "}\n",
+    "\n",
+    "for language, text in phrases.items():\n",
+    "    print(language)\n",
+    "    display(speak(text, voice_id=demo_voice, path=f\"speech_{language}.mp3\"))"
+   ],
+   "id": "cell-17"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Streaming and audio formats\n",
+    "\n",
+    "For interactive apps you usually want to start playing audio before the whole clip is generated. Set `stream=True` and consume the `speech.audio.delta` events. Below we measure time-to-first-audio for two formats — `mp3` (compressed) and `pcm` (raw) — and play back the streamed `mp3`."
+   ],
+   "id": "cell-18"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def stream_speech(text, voice_id, response_format=\"mp3\"):\n",
+    "    \"\"\"Stream speech; return (time_to_first_audio_seconds, joined_audio_bytes).\"\"\"\n",
+    "    start = time.time()\n",
+    "    first = None\n",
+    "    chunks = []\n",
+    "    with client.audio.speech.complete(\n",
+    "        model=TTS_MODEL,\n",
+    "        input=text,\n",
+    "        voice_id=voice_id,\n",
+    "        response_format=response_format,\n",
+    "        stream=True,\n",
+    "    ) as stream:\n",
+    "        for event in stream:\n",
+    "            if event.event == \"speech.audio.delta\":\n",
+    "                if first is None:\n",
+    "                    first = time.time() - start\n",
+    "                chunks.append(base64.b64decode(event.data.audio_data))\n",
+    "            elif event.event == \"speech.audio.done\":\n",
+    "                break\n",
+    "    return first, b\"\".join(chunks)\n",
+    "\n",
+    "\n",
+    "text = \"Streaming lets you start playback before the whole clip is ready.\"\n",
+    "for fmt in [\"mp3\", \"pcm\"]:\n",
+    "    ttfa, audio = stream_speech(text, \"gb_jane_neutral\", fmt)\n",
+    "    print(f\"{fmt:>3}: time-to-first-audio = {ttfa:.2f}s, total bytes = {len(audio):,}\")"
+   ],
+   "id": "cell-19"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save and play the streamed mp3.\n",
+    "_, mp3_bytes = stream_speech(text, \"gb_jane_neutral\", \"mp3\")\n",
+    "Path(\"streamed.mp3\").write_bytes(mp3_bytes)\n",
+    "Audio(filename=\"streamed.mp3\")"
+   ],
+   "id": "cell-20"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. A minimal voice-reply agent\n",
+    "\n",
+    "Putting it together: an LLM writes a short reply, and Voxtral speaks it. This is the output half of a voice assistant (pair it with Voxtral transcription for the input half)."
+   ],
+   "id": "cell-21"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_prompt = \"In one or two sentences, why is text-to-speech useful for accessibility?\"\n",
+    "\n",
+    "response = client.chat.complete(\n",
+    "    model=\"mistral-small-latest\",\n",
+    "    messages=[\n",
+    "        {\"role\": \"system\", \"content\": \"You are concise. Reply in 1-2 plain sentences, no markdown.\"},\n",
+    "        {\"role\": \"user\", \"content\": user_prompt},\n",
+    "    ],\n",
+    ")\n",
+    "reply = response.choices[0].message.content\n",
+    "print(\"Assistant:\", reply)\n",
+    "\n",
+    "speak(reply, voice_id=demo_voice, path=\"assistant_reply.mp3\")"
+   ],
+   "id": "cell-22"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleanup\n",
+    "\n",
+    "Remove the cloned voice if we created one (preset voices need no cleanup)."
+   ],
+   "id": "cell-23"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if clone_voice_id:\n",
+    "    client.audio.voices.delete(voice_id=clone_voice_id)\n",
+    "    print(\"Deleted\", clone_voice_id)\n",
+    "else:\n",
+    "    print(\"No custom voice was created — nothing to clean up.\")"
+   ],
+   "id": "cell-24"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Appendix — running the open weights locally\n",
+    "\n",
+    "Voxtral TTS is released under Apache-2.0, so you can self-host it for offline or high-volume use. The model is `mistralai/Voxtral-4B-TTS-2603` (~4B parameters). It needs a GPU and **will not run on a free Colab CPU runtime**; a single mid-range GPU is enough.\n",
+    "\n",
+    "```bash\n",
+    "pip install vllm\n",
+    "vllm serve mistralai/Voxtral-4B-TTS-2603\n",
+    "```\n",
+    "\n",
+    "Once served, it exposes the same OpenAI-compatible `/v1/audio/speech` interface used above. You can point the SDK at your local endpoint with `Mistral(api_key=\"...\", server_url=\"http://localhost:8000\")`. See the [model card](https://huggingface.co/mistralai/Voxtral-4B-TTS-2603) for hardware and quantization options."
+   ],
+   "id": "cell-25"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrap-up\n",
+    "\n",
+    "You generated speech with preset voices, cloned a voice zero-shot, transferred it across languages, streamed audio with latency measurements, and built a small LLM → speech reply loop — then saw how to run the open weights locally.\n",
+    "\n",
+    "**Where to go next**\n",
+    "\n",
+    "- [Voxtral TTS documentation](https://docs.mistral.ai/studio-api/audio/text_to_speech)\n",
+    "- [Audio understanding & transcription](https://docs.mistral.ai/capabilities/audio)\n",
+    "- [Agents API](https://docs.mistral.ai/studio-api/agents/introduction) — combine transcription + reasoning + TTS into a full voice agent"
+   ],
+   "id": "cell-26"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Description

Adds a cookbook for **Voxtral TTS**, covering the text-to-speech (output) side of the Voxtral family — complementary to the in-flight audio *input* cookbooks (transcription, diarization, Q&A). It walks through preset voices, zero-shot voice cloning, cross-lingual transfer, streaming with latency/format comparison, and a minimal LLM → speech voice-reply agent, plus an appendix on running the open weights locally.

The notebook uses the `mistralai` 2.x SDK (`client.audio.speech` / `client.audio.voices`), is self-contained (it synthesizes its own reference clip — no audio assets committed), and falls back to a preset voice when custom-voice cloning isn't available on the account, so it runs end to end on any plan. No API keys are included. It lives in `mistral/tts/`, alongside the existing `sts_demo.py` TTS example.

Dependencies: `mistralai==2.5.0`

## Type of Change

- [x] New Cookbook
  - [x] Notebook File
    - [x] Does it work on google colab?
- [x] README.md Update

## Cookbook Checklist:

- [x] My code is easy to read and well structured.
- [x] I've tagged the versions of any dependency required.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or errors.

## README.md Checklist

- [x] I've added my cookbook to the table.

## Additional Context

Model: `voxtral-mini-tts-2603` via `client.audio.speech.complete`. Verified end to end by executing the full notebook with a real key — preset voices, cross-lingual generation, streaming, and the chat → speech loop all produce valid audio.
