### PR TITLE
Add Nika: statically-checked Mistral workflows (third_party)

### DIFF
--- a/third_party/Nika/README.md
+++ b/third_party/Nika/README.md
@@ -1,0 +1,51 @@
+# Nika: statically-checked Mistral workflows
+
+[Nika](https://github.com/supernovae-st/nika) turns a repeated AI job into one
+plain-text `.nika.yaml` file: a small DAG that is **statically audited before a
+single token is spent** and leaves a hash-chained trace after it runs. This
+example orchestrates Mistral to draft release notes from a git log.
+
+## Why it pairs well with Mistral
+
+Run `nika check` and you get a receipt before anything executes:
+
+```
+✔ COST     $0.0012 - $0.0012 worst-case ceiling
+✔ SECRETS  no information-flow escapes
+✔ PERMITS  body fits the declared boundary
+```
+
+The cost ceiling is real because Mistral is in the model catalog: the checker
+prices `mistral-large-latest` from the declared token cap. You see what a run
+can cost, which secrets flow where, and the whole plan, before you spend.
+
+## Run it
+
+```bash
+brew install supernovae-st/tap/nika    # single binary
+export MISTRAL_API_KEY=...
+
+nika check release-notes.nika.yaml     # the receipt, before any token
+nika run   release-notes.nika.yaml     # git log -> Mistral -> RELEASE_NOTES.md
+```
+
+## The workflow, drawn by nika itself
+
+```mermaid
+graph TD
+  log["log · exec"]
+  notes["notes · infer · mistral/mistral-large-latest"]
+  save["save · invoke · nika:write"]
+  log --> notes
+  notes --> save
+```
+
+Three tasks: read the git log, draft the notes with Mistral, save. The
+`permits:` boundary is declared tight (exec may only launch git, the only tool
+is `nika:write`), so the checker enforces it and everything else is
+default-deny.
+
+Swap `mistral-large-latest` for `mistral-small-latest` to cut the cost ceiling,
+or point `model:` at any other provider in one line. The logic does not change.
+
+Engine is AGPL-3.0; the language spec is Apache-2.0. Contributed by the Nika author.

--- a/third_party/Nika/release-notes.nika.yaml
+++ b/third_party/Nika/release-notes.nika.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://nika.sh/spec/v1/workflow.schema.json
+#
+# Draft release notes from a git log, with Mistral, checked before a token
+# is spent. Run `nika check` and you see the plan, the honest cost floor and
+# which secrets flow where BEFORE anything runs. Then:
+#   nika run release-notes.nika.yaml
+nika: v1
+workflow: mistral-release-notes
+description: "git log since the last tag -> Mistral drafts release notes -> save"
+
+model: mistral/mistral-large-latest    # EU provider; MISTRAL_API_KEY read from the env
+
+vars:
+  out_path: "./RELEASE_NOTES.md"
+
+permits:
+  exec: ["git"]
+  tools: ["nika:write"]
+
+tasks:
+  - id: log
+    exec:
+      command: ["git", "log", "--pretty=format:- %s", "-n", "50"]
+      capture: structured
+
+  - id: notes
+    depends_on: [log]
+    with:
+      commits: ${{ tasks.log.output.stdout }}
+    infer:
+      system: "You write concise, developer-facing release notes."
+      prompt: |
+        Turn these commit subjects into grouped release notes under
+        Features, Fixes and Chores. Keep it terse and factual.
+        ${{ with.commits }}
+      max_tokens: 800
+
+  - id: save
+    depends_on: [notes]
+    invoke:
+      tool: "nika:write"
+      args:
+        path: "${{ vars.out_path }}"
+        content: "${{ tasks.notes.output }}"
+        overwrite: true
+
+outputs:
+  notes_path:
+    value: ${{ vars.out_path }}
+    type: string
+    description: "where the drafted notes were written"


### PR DESCRIPTION
Adds `third_party/Nika/` next to the other vendor integrations (CAMEL, Chainlit, Haystack, LlamaIndex).

[Nika](https://github.com/supernovae-st/nika) turns a repeated AI job into one plain-text `.nika.yaml` file, statically audited before a single token is spent. The example orchestrates Mistral to draft release notes from a git log, and the value shows on `nika check`: because Mistral is in the model catalog, the checker prints a real cost ceiling (`$0.0012`) plus the secret flows and the permits boundary, before anything runs.

Proven before this PR: `nika check` green, 0 hints, cost ceiling priced from `mistral-large-latest`. The DAG in the README is generated by `nika graph`, not drawn by hand.

Full disclosure: I'm the Nika author. Engine AGPL-3.0, spec Apache-2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)