### PR TITLE
Update mistral-search-engine.ipynb to SDK v1

### DIFF
--- a/mistral/rag/mistral-search-engine.ipynb
+++ b/mistral/rag/mistral-search-engine.ipynb
@@ -55,7 +55,7 @@
     }
    ],
    "source": [
-    "!pip install aiohttp==3.9.5 beautifulsoup4==4.12.3 faiss_cpu==1.8.0 mistralai==0.4.0 nest_asyncio==1.6.0 numpy==1.26.4 pandas==2.2.2 python-dotenv==1.0.1 requests==2.32.3\n"
+    "!pip install aiohttp==3.9.5 beautifulsoup4==4.12.3 faiss_cpu==1.8.0 mistralai nest_asyncio==1.6.0 numpy==1.26.4 pandas==2.2.2 python-dotenv==1.0.1 requests==2.32.3\n"
    ]
   },
   {
@@ -110,8 +110,7 @@
     "import pandas as pd\n",
     "import faiss\n",
     "import numpy as np\n",
-    "from mistralai.client import MistralClient\n",
-    "from mistralai.models.chat_completion import ChatMessage\n",
+    "from mistralai import Mistral\n",
     "\n",
     "# Apply the nest_asyncio patch\n",
     "nest_asyncio.apply()\n",
@@ -127,7 +126,7 @@
     "faiss_index_path = 'faiss_index.index'\n",
     "\n",
     "mistral_api_key = MISTRAL_API_KEY  # replace with your actual API key\n",
-    "client = MistralClient(api_key=mistral_api_key)\n",
+    "client = Mistral(api_key=mistral_api_key)\n",
     "\n",
     "async def fetch(session, url, params=None):\n",
     "    async with session.get(url, params=params, headers=headers, timeout=30) as response:\n",
@@ -193,7 +192,7 @@
     "    return await asyncio.gather(*tasks)\n",
     "\n",
     "async def get_embeddings_from_mistral(client, text_chunks):\n",
-    "    response = client.embeddings(model=\"mistral-embed\", input=text_chunks)\n",
+    "    response = client.embeddings.create(model=\"mistral-embed\", inputs=text_chunks)\n",
     "    return [embedding.embedding for embedding in response.data]\n",
     "\n",
     "async def fetch_and_process_data(search_query):\n",
@@ -341,8 +340,8 @@
     "    :param texts: List of texts to convert to embeddings.\n",
     "    :return: List of embeddings.\n",
     "    \"\"\"\n",
-    "    client = MistralClient(api_key=MISTRAL_API_KEY)\n",
-    "    response = client.embeddings(model=\"mistral-embed\", input=[texts])\n",
+    "    client = Mistral(api_key=MISTRAL_API_KEY)\n",
+    "    response = client.embeddings.create(model=\"mistral-embed\", inputs=[texts])\n",
     "    return [embedding.embedding for embedding in response.data]\n",
     "\n",
     "\n",
@@ -475,7 +474,7 @@
    "outputs": [],
    "source": [
     "messages = [\n",
-    "    ChatMessage(role=\"user\", content=\"What happend during apple WWDC 2024?\"),\n",
+    "    {\"role\": \"user\", \"content\": \"What happend during apple WWDC 2024?\"},\n",
     "]\n",
     "\n"
    ]
@@ -499,8 +498,8 @@
    "source": [
     "model = \"mistral-large-latest\"\n",
     "\n",
-    "client = MistralClient(api_key=MISTRAL_API_KEY)\n",
-    "response = client.chat(model=model, messages=messages, tools=tools, tool_choice=\"any\")\n",
+    "client = Mistral(api_key=MISTRAL_API_KEY)\n",
+    "response = client.chat.complete(model=model, messages=messages, tools=tools, tool_choice=\"any\")\n",
     "response"
    ]
   },
@@ -585,9 +584,9 @@
     }
    ],
    "source": [
-    "messages.append(ChatMessage(role=\"tool\", name=function_name, content=function_result, tool_call_id=tool_call.id))\n",
+    "messages.append({\"role\": \"tool\", \"name\": function_name, \"content\": function_result, \"tool_call_id\": tool_call.id})\n",
     "\n",
-    "response = client.chat(model=model, messages=messages)\n",
+    "response = client.chat.complete(model=model, messages=messages)\n",
     "response.choices[0].message.content\n",
     "\n"
    ]
@@ -609,8 +608,8 @@
     "\n",
     "while True:\n",
     "    input_ = input(\"Ask: \")\n",
-    "    messages.append(ChatMessage(role=\"user\", content=input_))\n",
-    "    response = client.chat(model=model, messages=messages, tools=tools, tool_choice=\"any\")\n",
+    "    messages.append({\"role\": \"user\", \"content\": input_})\n",
+    "    response = client.chat.complete(model=model, messages=messages, tools=tools, tool_choice=\"any\")\n",
     "    messages.append(response.choices[0].message)\n",
     "    print(response.choices[0].message.content)\n",
     "    tool_call = response.choices[0].message.tool_calls[0]\n",
@@ -620,9 +619,9 @@
     "    function_result_raw = names_to_functions[function_name](**function_params)\n",
     "    print(\"sources: \", [f\"{source['title']} - {source['url']}\" for source in function_result_raw])\n",
     "    function_result_text = tools_to_str(function_result_raw)\n",
-    "    messages.append(ChatMessage(role=\"tool\", name=function_name, content=function_result_text, tool_call_id=tool_call.id))\n",
+    "    messages.append({\"role\": \"tool\", \"name\": function_name, \"content\": function_result_text, \"tool_call_id\": tool_call.id})\n",
     "\n",
-    "    response = client.chat(model=model, messages=messages)\n",
+    "    response = client.chat.complete(model=model, messages=messages)\n",
     "    final_response = response.choices[0].message.content\n",
     "    print(final_response)\n"
    ]


### PR DESCRIPTION
Resolves #304.

## Changes

Migrates `mistral/rag/mistral-search-engine.ipynb` from the deprecated v0 `mistralai` SDK to v1:

| Before | After |
|---|---|
| `from mistralai.client import MistralClient` | `from mistralai import Mistral` |
| `from mistralai.models.chat_completion import ChatMessage` | removed |
| `MistralClient(api_key=...)` | `Mistral(api_key=...)` |
| `client.embeddings(model=..., input=...)` | `client.embeddings.create(model=..., inputs=...)` |
| `client.chat(...)` | `client.chat.complete(...)` |
| `ChatMessage(role=..., content=...)` | plain dicts `{"role": ..., "content": ...}` |
| `mistralai==0.4.0` (pinned) | `mistralai` (latest) |

## Testing

Verified clean with the stale cookbook checker:

```
python skills/check-stale-cookbooks/check_stale.py \
  --file mistral/rag/mistral-search-engine.ipynb --no-fetch
```

```
✅ No stale content found.
Exit code: 0
```