### PR TITLE
Use getpass for notebook API key input

### DIFF
--- a/mistral/connectors/01-build-a-database-advisor-agent.ipynb
+++ b/mistral/connectors/01-build-a-database-advisor-agent.ipynb
@@ -33,7 +33,7 @@
   {
    "cell_type": "markdown",
    "id": "52w71bir4h7",
-   "source": "## Environment setup\n\nInstall the Mistral Python SDK by running the cell below.\n\nTo complete this cookbook, you'll need a Mistral API key. In [Studio](https://console.mistral.ai), navigate to the [API keys section](https://console.mistral.ai/home?profile_dialog=api-keys) and create a new API key, then set it as an environment variable before running the client cell:\n\n```\nMISTRAL_API_KEY=your-mistral-api-key\n```",
+   "source": "## Environment setup\n\nInstall the Mistral Python SDK by running the cell below.\n\nTo complete this cookbook, you'll need a Mistral API key. In [Studio](https://console.mistral.ai), navigate to the [API keys section](https://console.mistral.ai/home?profile_dialog=api-keys) and create a new API key.\n\nSet it before running the client cell using one of these options:\n\n**Option 1 — environment variable** (recommended for local use):\n\n```\nMISTRAL_API_KEY=your-mistral-api-key\n```\n\n**Option 2 — enter it when prompted**: if `MISTRAL_API_KEY` is not already set in your environment, the next code cell will display a secure input field where you can paste your key directly.",
    "metadata": {}
   },
   {
@@ -52,14 +52,7 @@
    "id": "c3d4e5f6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "import re\n",
-    "\n",
-    "from mistralai import Mistral\n",
-    "\n",
-    "client = Mistral(api_key=os.environ[\"MISTRAL_API_KEY\"])"
-   ]
+   "source": "import getpass\nimport os\nimport re\n\nfrom mistralai import Mistral\n\nif not os.environ.get(\"MISTRAL_API_KEY\"):\n    os.environ[\"MISTRAL_API_KEY\"] = getpass.getpass(\"Mistral API key: \")\n\nclient = Mistral(api_key=os.environ[\"MISTRAL_API_KEY\"])"
   },
   {
    "cell_type": "markdown",

--- a/skills/cookbook-review/SKILL.md
+++ b/skills/cookbook-review/SKILL.md
@@ -144,23 +144,28 @@ Flag as Moderate:
 
 #### Notebook (.ipynb) API key cell
 
-Jupyter notebooks must load the key from the environment via dotenv. The first code cell (or the first cell that touches the API key) must follow this pattern:
+Jupyter notebooks must use the following pattern for the API key. It checks for an existing environment variable first, and falls back to a secure `getpass` prompt so readers can enter their key directly in the notebook without setting up a `.env` file:
 
 ```python
-from dotenv import load_dotenv
+import getpass
 import os
 
-load_dotenv()
-api_key = os.environ["MISTRAL_API_KEY"]
+if not os.environ.get("MISTRAL_API_KEY"):
+    os.environ["MISTRAL_API_KEY"] = getpass.getpass("Mistral API key: ")
 ```
+
+The client is then initialized with `os.environ["MISTRAL_API_KEY"]`. `getpass` is part of the Python standard library — no extra dependency needed. The prompt is masked like a password field and works in Jupyter, Colab, and Kaggle.
+
+The `## Environment setup` section in the notebook must explain both options:
+1. Set `MISTRAL_API_KEY` as an environment variable before running (for local use)
+2. Leave it unset and enter the key when prompted by the cell above
 
 Flag these as Critical:
 - Hard-coded API key strings in any cell
 - `MISTRAL_KEY` instead of `MISTRAL_API_KEY`
-- Using `os.getenv("MISTRAL_API_KEY")` without a fallback or error — prefer `os.environ["MISTRAL_API_KEY"]` so the notebook fails loudly if the key is missing
+- Using `os.getenv("MISTRAL_API_KEY")` without a fallback — prefer `os.environ["MISTRAL_API_KEY"]` or the `getpass` pattern so the notebook fails loudly if the key is missing
 
 Flag as Moderate:
-- Missing `load_dotenv()` call when a `.env` file is expected
 - `api_key = os.environ["MISTRAL_API_KEY"]` defined but never passed to the client constructor
 
 #### Shell / curl cookbooks


### PR DESCRIPTION
## Summary

- Notebooks now prompt for the API key interactively if `MISTRAL_API_KEY` is not already set in the environment
- Updates `01-build-a-database-advisor-agent.ipynb` to use the new pattern
- Updates `SKILL.md` to document this as the standard for all cookbook notebooks

## What changed

The old approach required readers to set up a `.env` file or export an environment variable before running any cell. The new pattern uses Python's built-in `getpass`:

```python
import getpass
import os

if not os.environ.get("MISTRAL_API_KEY"):
    os.environ["MISTRAL_API_KEY"] = getpass.getpass("Mistral API key: ")
```

If the key is already in the environment, the cell passes silently. If not, a masked input field appears inline — no `.env` file, no extra dependencies, works in Jupyter, Colab, and Kaggle.

The environment setup section in the notebook now explains both options: set the env var ahead of time, or enter the key when prompted.

## Test plan

- [ ] Run `01-build-a-database-advisor-agent.ipynb` without `MISTRAL_API_KEY` set and confirm the prompt appears
- [ ] Run it with `MISTRAL_API_KEY` already in the environment and confirm no prompt appears