### PR TITLE
Fix winner regex and improve review_pr inline comment bundling

### DIFF
--- a/mistral/connectors/01-build-a-database-advisor-agent.ipynb
+++ b/mistral/connectors/01-build-a-database-advisor-agent.ipynb
@@ -27,32 +27,73 @@
   {
    "cell_type": "markdown",
    "id": "azmowi619b5",
-   "source": "## Prerequisites\n\nTo complete this notebook, you will need:\n- Python 3.9 or later\n- A Mistral account and API key",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "To complete this notebook, you will need:\n",
+    "- Python 3.9 or later\n",
+    "- A Mistral account and API key"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "52w71bir4h7",
-   "source": "## Environment setup\n\nInstall the Mistral Python SDK by running the cell below.\n\nTo complete this cookbook, you'll need a Mistral API key. In [Studio](https://console.mistral.ai), navigate to the [API keys section](https://console.mistral.ai/home?profile_dialog=api-keys) and create a new API key.\n\nSet it before running the client cell using one of these options:\n\n**Option 1 — environment variable** (recommended for local use):\n\n```\nMISTRAL_API_KEY=your-mistral-api-key\n```\n\n**Option 2 — enter it when prompted**: if `MISTRAL_API_KEY` is not already set in your environment, the next code cell will display a secure input field where you can paste your key directly.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Environment setup\n",
+    "\n",
+    "Install the Mistral Python SDK by running the cell below.\n",
+    "\n",
+    "To complete this cookbook, you'll need a Mistral API key. In [Studio](https://console.mistral.ai), navigate to the [API keys section](https://console.mistral.ai/home?profile_dialog=api-keys), choose **Private and shared connectors** for **Connector access scope** and create a new API key. \n",
+    "\n",
+    "Set it before running the client cell using one of these options:\n",
+    "\n",
+    "**Option 1 — environment variable** (recommended for local use):\n",
+    "\n",
+    "```\n",
+    "MISTRAL_API_KEY=your-mistral-api-key\n",
+    "```\n",
+    "\n",
+    "**Option 2 — enter it when prompted**: if `MISTRAL_API_KEY` is not already set in your environment, the next code cell will display a secure input field where you can paste your key directly."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "b2c3d4e5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install mistralai --quiet"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "c3d4e5f6",
    "metadata": {},
    "outputs": [],
-   "source": "import getpass\nimport os\nimport re\n\nfrom mistralai import Mistral\n\nif not os.environ.get(\"MISTRAL_API_KEY\"):\n    os.environ[\"MISTRAL_API_KEY\"] = getpass.getpass(\"Mistral API key: \")\n\nclient = Mistral(api_key=os.environ[\"MISTRAL_API_KEY\"])"
+   "source": [
+    "import getpass\n",
+    "import os\n",
+    "import re\n",
+    "\n",
+    "from mistralai.client import Mistral\n",
+    "\n",
+    "if not os.environ.get(\"MISTRAL_API_KEY\"):\n",
+    "    os.environ[\"MISTRAL_API_KEY\"] = getpass.getpass(\"Mistral API key: \")\n",
+    "\n",
+    "client = Mistral(api_key=os.environ[\"MISTRAL_API_KEY\"])"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -68,10 +109,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "e5f6a7b8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created: showdown_sqlite  (id=019f8eb1-a4f7-741f-89d8-ead5578f579a)\n",
+      "Created: showdown_duckdb  (id=019f8eb1-abf9-75c1-80f6-346460a1dc34)\n",
+      "Created: showdown_leveldb  (id=019f8eb1-b2ff-7571-9914-a073d82908d4)\n"
+     ]
+    }
+   ],
    "source": [
     "DEEPWIKI_URL = \"https://mcp.deepwiki.com/mcp\"\n",
     "\n",
@@ -107,10 +158,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "a7b8c9d0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 showdown connectors registered:\n",
+      "\n",
+      "  showdown_sqlite         DeepWiki connector — sqlite/sqlite\n",
+      "  showdown_duckdb         DeepWiki connector — duckdb/duckdb\n",
+      "  showdown_leveldb        DeepWiki connector — google/leveldb\n"
+     ]
+    }
+   ],
    "source": [
     "page = await client.beta.connectors.list_async(page_size=50)\n",
     "showdown = [c for c in page.items if c.name.startswith(\"showdown_\")]\n",
@@ -134,10 +197,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "c9d0e1f2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Agent ready: Database Showdown Judge  (id=ag_019f8eb1b4cd76349125e8e58f662b2d)\n"
+     ]
+    }
+   ],
    "source": [
     "agent = await client.beta.agents.create_async(\n",
     "    name=\"Database Showdown Judge\",\n",
@@ -173,10 +244,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "e1f2a3b4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Here’s a direct, data-driven comparison of **SQLite**, **DuckDB**, and **LevelDB** for a **write-heavy local analytics workload**, based on their storage models, ACID guarantees, query capabilities, write throughput, and Python API simplicity:\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### **1. Storage Model**\n",
+      "- **SQLite**: Row-oriented, disk-based (single-file). Optimized for transactional workloads but not columnar analytics.\n",
+      "- **DuckDB**: Columnar, in-memory-first with optional persistence. Optimized for analytical queries (vectorized execution).\n",
+      "- **LevelDB**: Key-value store (LSM-tree). Designed for high write throughput but not analytics (no native SQL).\n",
+      "\n",
+      "**Winner for analytics**: DuckDB (columnar storage).\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### **2. ACID Guarantees**\n",
+      "- **SQLite**: Full ACID (transactions, atomic writes, durability).\n",
+      "- **DuckDB**: Full ACID (transactions, atomic writes, durability).\n",
+      "- **LevelDB**: Atomic writes only (no multi-operation transactions).\n",
+      "\n",
+      "**Winner for reliability**: SQLite/DuckDB (tie).\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### **3. Query Capabilities**\n",
+      "- **SQLite**: Full SQL (joins, aggregations, window functions). Limited to row-based execution.\n",
+      "- **DuckDB**: Full SQL + analytical extensions (e.g., `GROUP BY ALL`, nested types). Optimized for OLAP.\n",
+      "- **LevelDB**: No SQL (key-value lookups only). Requires manual indexing for analytics.\n",
+      "\n",
+      "**Winner for analytics**: DuckDB.\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### **4. Write Throughput**\n",
+      "- **SQLite**: ~10K–50K writes/sec (bottlenecked by WAL and fsync).\n",
+      "- **DuckDB**: ~50K–200K writes/sec (append-only storage, no fsync by default).\n",
+      "- **LevelDB**: ~100K–500K writes/sec (LSM-tree, no fsync by default).\n",
+      "\n",
+      "**Winner for write-heavy**: LevelDB (but sacrifices query flexibility).\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### **5. Python API Simplicity**\n",
+      "- **SQLite**: Built into Python (`sqlite3` module). Simple but limited to row-based operations.\n",
+      "- **DuckDB**: `duckdb` Python library (Pandas integration, SQL-first). Clean and intuitive.\n",
+      "- **LevelDB**: `plyvel` (third-party). Low-level key-value API (not analytics-friendly).\n",
+      "\n",
+      "**Winner for simplicity**: DuckDB.\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### **Trade-offs Summary**\n",
+      "| Database  | Storage  | ACID | Query Power | Write Speed | Python API |\n",
+      "|-----------|----------|------|-------------|-------------|------------|\n",
+      "| SQLite    | Row      | ✅   | Good        | Slow        | Simple     |\n",
+      "| DuckDB    | Columnar | ✅   | Excellent   | Fast        | Simple     |\n",
+      "| LevelDB   | Key-Value| ❌   | None        | Very Fast   | Complex    |\n",
+      "\n",
+      "---\n",
+      "\n",
+      "### **Final Verdict**\n",
+      "For a **write-heavy local analytics workload**, **DuckDB** is the best balance:\n",
+      "- **Columnar storage** for analytics.\n",
+      "- **Full ACID** for reliability.\n",
+      "- **High write throughput** (faster than SQLite, slower than LevelDB but with SQL).\n",
+      "- **Simple Python API** (Pandas integration, SQL-first).\n",
+      "\n",
+      "**RECOMMENDATION: showdown_duckdb**\n"
+     ]
+    }
+   ],
    "source": [
     "response = await client.beta.conversations.start_async(\n",
     "    agent_id=agent.id,\n",
@@ -214,17 +358,7 @@
    "id": "f2a3b4c5",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "match = re.search(r\"RECOMMENDATION:\\s*(\\S+)\", full_text)\n",
-    "if not match:\n",
-    "    raise ValueError(\"Agent did not return a RECOMMENDATION line — re-run the cell above.\")\n",
-    "\n",
-    "winner_name = match.group(1).strip()\n",
-    "loser_names = [name for name in connectors if name != winner_name]\n",
-    "\n",
-    "print(f\"Winner: {winner_name}\")\n",
-    "print(f\"Losers: {', '.join(loser_names)}\")"
-   ]
+   "source": "match = re.search(r\"RECOMMENDATION:\\s*([\\w]+)\", full_text)\nif not match:\n    raise ValueError(\"Agent did not return a RECOMMENDATION line — re-run the cell above.\")\n\nwinner_name = match.group(1).strip()\nloser_names = [name for name in connectors if name != winner_name]\n\nprint(f\"Winner: {winner_name}\")\nprint(f\"Losers: {', '.join(loser_names)}\")"
   },
   {
    "cell_type": "markdown",
@@ -238,10 +372,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "b4c5d6e7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'showdown_duckdb**'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mKeyError\u001b[39m                                  Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[19]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Mark the winner\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m winner_connector = connectors[winner_name]\n\u001b[32m      3\u001b[39m updated = await client.beta.connectors.update_async(\n\u001b[32m      4\u001b[39m     connector_id=winner_connector.id,\n\u001b[32m      5\u001b[39m     description=f\"[SELECTED] {winner_connector.description}\",\n",
+      "\u001b[31mKeyError\u001b[39m: 'showdown_duckdb**'"
+     ]
+    }
+   ],
    "source": [
     "# Mark the winner\n",
     "winner_connector = connectors[winner_name]\n",
@@ -325,13 +471,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv (3.14.6.final.0)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.6"
   }
  },
  "nbformat": 4,

--- a/skills/cookbook-review/review_pr.py
+++ b/skills/cookbook-review/review_pr.py
@@ -570,8 +570,19 @@ def _build_file_comment_body(filepath: str, fc: dict) -> str:
 # ── GitHub posting ────────────────────────────────────────────────────────────
 
 
-def post_verdict_review(filepath: str, summary: str, verdict: str) -> None:
-    """Post a lightweight review event with just the summary — no bundled inline comments."""
+def post_verdict_review(
+    filepath: str,
+    summary: str,
+    verdict: str,
+    bundled_comments: list[dict] | None = None,
+) -> bool:
+    """
+    Post a review event with optional bundled inline comments.
+
+    Returns True on success, False if GitHub rejects the payload (HTTP 422).
+    Bundled inline comments must reference lines that are present in the diff;
+    a single invalid line causes the entire request to be rejected.
+    """
     event_map = {
         "approve": "APPROVE",
         "request_changes": "REQUEST_CHANGES",
@@ -589,12 +600,18 @@ def post_verdict_review(filepath: str, summary: str, verdict: str) -> None:
         "commit_id": HEAD_SHA,
         "body": body,
         "event": gh_event,
-        "comments": [],
+        "comments": bundled_comments or [],
     }
     url = f"{GITHUB_API}/repos/{REPO}/pulls/{PR_NUMBER}/reviews"
     resp = requests.post(url, headers=GH_HEADERS, json=payload, timeout=30)
+    if resp.status_code == 422:
+        n = len(bundled_comments) if bundled_comments else 0
+        print(f"  Review with {n} bundled comment(s) got HTTP 422 — retrying without them.")
+        return False
     resp.raise_for_status()
-    print(f"  Posted {gh_event} verdict review.")
+    n = len(bundled_comments) if bundled_comments else 0
+    print(f"  Posted {gh_event} review with {n} bundled inline comment(s).")
+    return True
 
 
 def post_line_comment(path: str, line: int, body: str) -> bool:
@@ -626,43 +643,108 @@ def post_pr_comment(body: str) -> None:
     resp.raise_for_status()
 
 
-def post_review(filepath: str, review: dict, total_lines: int, file_lines: list[str] | None = None) -> None:
+def _strip_suggestion_block(body: str) -> str:
     """
-    Post the review as separate comments:
-    1. One lightweight verdict review (summary only, no bundled comments).
-    2. One separate inline comment per line_comment issue.
-    3. One separate PR comment per file_comment issue.
+    Remove ```suggestion ... ``` fences from a comment body.
+
+    Suggestion blocks only render as Apply buttons inside PR review inline
+    comments. In PR conversation comments they display as plain code, which
+    is misleading. Replace the fence with a plain "Suggested fix:" label.
+    """
+    lines = body.splitlines()
+    result: list[str] = []
+    in_suggestion = False
+    suggestion_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "```suggestion":
+            in_suggestion = True
+            suggestion_lines = []
+        elif in_suggestion and stripped == "```":
+            in_suggestion = False
+            if suggestion_lines:
+                result.append("**Suggested fix:** " + suggestion_lines[0])
+                result.extend(suggestion_lines[1:])
+        elif in_suggestion:
+            suggestion_lines.append(line)
+        else:
+            result.append(line)
+    return "\n".join(result)
+
+
+def post_review(
+    filepath: str,
+    review: dict,
+    total_lines: int,
+    file_lines: list[str] | None = None,
+    added_lines_set: set[int] | None = None,
+) -> None:
+    """
+    Post the review, maximising the chance of inline Apply-button suggestions.
+
+    Strategy:
+    1. Bundle all valid inline comments into a single POST /pulls/.../reviews
+       request. Bundled review inline comments render Apply buttons reliably.
+    2. Only include a line if it is confirmed to be in the diff. For modified
+       files pass added_lines_set; for new files pass None (all lines are new).
+    3. If the bundled review is rejected (HTTP 422), retry without the bundled
+       comments, then try each inline comment individually with post_line_comment.
+    4. Any comment that cannot be posted inline is posted to the PR conversation
+       via post_pr_comment with the suggestion block stripped — suggestion fences
+       render as plain code in conversation comments, not as Apply buttons.
     """
     verdict = review.get("verdict", "comment")
     summary = review.get("summary", "")
-
-    post_verdict_review(filepath, summary, verdict)
 
     line_comments = review.get("line_comments", [])
     if file_lines:
         line_comments = _sanitize_line_comments(line_comments, file_lines)
 
-    n_inline = 0
-    n_fallback = 0
+    # Split into bundleable comments (line confirmed in diff) and fallback.
+    bundled: list[dict] = []
+    fallback_lcs: list[dict] = []
+
     for lc in line_comments:
         line = lc.get("line")
-        body = _build_line_comment_body(lc)
-        if isinstance(line, int) and 1 <= line <= total_lines:
-            if post_line_comment(filepath, line, body):
-                n_inline += 1
-                continue
-        else:
-            print(f"    Out-of-range line={line!r} — posting as PR comment.")
-        post_pr_comment(body)
-        n_fallback += 1
+        if not isinstance(line, int) or line < 1 or (total_lines > 0 and line > total_lines):
+            print(f"    Out-of-range line={line!r} — will post as PR comment.")
+            fallback_lcs.append(lc)
+            continue
+        if added_lines_set is not None and line not in added_lines_set:
+            print(f"    Line {line} not in diff — will post as PR comment.")
+            fallback_lcs.append(lc)
+            continue
+        bundled.append({
+            "path": filepath,
+            "line": line,
+            "side": "RIGHT",
+            "body": _build_line_comment_body(lc),
+        })
 
+    # Post the verdict review with all bundled inline comments in one request.
+    ok = post_verdict_review(filepath, summary, verdict, bundled)
+
+    if not ok:
+        # Retry verdict review without inline comments.
+        post_verdict_review(filepath, summary, verdict, [])
+        # Attempt each previously-bundled comment individually.
+        for bc in bundled:
+            if not post_line_comment(bc["path"], bc["line"], bc["body"]):
+                post_pr_comment(_strip_suggestion_block(bc["body"]))
+
+    # Post fallback comments (line not in diff) without suggestion blocks.
+    n_fallback = len(fallback_lcs)
+    for lc in fallback_lcs:
+        post_pr_comment(_strip_suggestion_block(_build_line_comment_body(lc)))
+
+    # Post file-level and cell-level comments.
     n_file = 0
     for fc in review.get("file_comments", []):
         post_pr_comment(_build_file_comment_body(filepath, fc))
         n_file += 1
 
     print(
-        f"  {n_inline} inline comment(s), "
+        f"  {len(bundled)} bundled inline comment(s), "
         f"{n_fallback} fallback PR comment(s), "
         f"{n_file} file-level PR comment(s)."
     )
@@ -705,6 +787,7 @@ def main() -> None:
         is_modified_md = is_modified and not is_notebook
 
         raw_lines: list[str] | None = None
+        added_lines_set: set[int] | None = None
 
         if is_modified and is_notebook:
             # Modified notebook: show only changed cells (no line numbers available).
@@ -716,7 +799,9 @@ def main() -> None:
             print(f"  {total} changed cell(s).")
         elif is_modified_md:
             # Modified Markdown: full file with [NEW] markers so the model can produce
-            # inline line_comments with committable suggestions.
+            # inline line_comments with committable suggestions. Track which lines are
+            # in the diff so we only bundle those — bundling a non-diff line causes a
+            # 422 that rejects the entire review request.
             added_lines_set = get_added_line_numbers(filepath)
             if not added_lines_set:
                 print("  No new lines detected — skipping review.")
@@ -759,7 +844,7 @@ def main() -> None:
 
         print("  Posting GitHub PR review ...")
         try:
-            post_review(filepath, review, 0 if is_notebook else total, raw_lines)
+            post_review(filepath, review, 0 if is_notebook else total, raw_lines, added_lines_set)
         except requests.HTTPError as exc:
             print(f"  Failed to post review: {exc}")
             print(f"  Response body: {exc.response.text[:500]}")


### PR DESCRIPTION
## Summary

- **Fix RECOMMENDATION parser regex** in `01-build-a-database-advisor-agent.ipynb`: changed `\S+` to `[\w]+` so markdown formatting (e.g. `**`) appended by the model to connector names is stripped, preventing all connectors from appearing as losers and a `KeyError` on lookup
- **Improve inline comment bundling** in `review_pr.py`: bundle inline comments into a single review request for reliable Apply-button rendering; fall back to individual `post_line_comment` on HTTP 422, and strip suggestion fences from PR conversation fallback comments

## Test plan

- [ ] Run `01-build-a-database-advisor-agent.ipynb` end-to-end and confirm winner/loser parsing works even when the model appends `**` to the connector name
- [ ] Trigger `review_pr.py` on a PR with modified Markdown files and confirm bundled inline comments render Apply buttons correctly