### PR TITLE
Database advisor agent: TypeScript project, SDK fixes, skill updates

### DIFF
--- a/mistral/connectors/01-build-a-database-advisor-agent.ipynb
+++ b/mistral/connectors/01-build-a-database-advisor-agent.ipynb
@@ -78,22 +78,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "c3d4e5f6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import getpass\n",
-    "import os\n",
-    "import re\n",
-    "\n",
-    "from mistralai.client import Mistral\n",
-    "\n",
-    "if not os.environ.get(\"MISTRAL_API_KEY\"):\n",
-    "    os.environ[\"MISTRAL_API_KEY\"] = getpass.getpass(\"Mistral API key: \")\n",
-    "\n",
-    "client = Mistral(api_key=os.environ[\"MISTRAL_API_KEY\"])"
-   ]
+   "source": "import getpass\nimport os\n\nfrom mistralai.client import Mistral\n\nif not os.environ.get(\"MISTRAL_API_KEY\"):\n    os.environ[\"MISTRAL_API_KEY\"] = getpass.getpass(\"Mistral API key: \")\n\nclient = Mistral(api_key=os.environ[\"MISTRAL_API_KEY\"])"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

- Fixes a regex bug where `**` markdown appended by the model caused a `KeyError` on winner lookup — replaced with JSON key lookup via `completion_args` + `json_schema`
- Adds a complete runnable TypeScript project (`database-advisor-agent/`) alongside the tutorial
- Fixes SDK issues found while testing: named import `{ Mistral }`, `updateConnectorRequest` field name, `dotenv` for `.env` loading
- Moves the tutorial's Run section to after Cleanup so it's only reached once the script is complete
- Simplifies agent instructions — JSON structure is enforced by `completion_args`, not prose
- Updates cookbook-review skill with per-package-manager code block formatting rule and API key sentence flexibility for scope context
- Removes unused `import re` from the Python notebook

## Test plan

- [ ] Python notebook runs end-to-end: connectors created, agent built, conversation started, tool calls logged, JSON parsed, winner updated, losers deleted
- [ ] TypeScript project (`cd mistral/connectors/database-advisor-agent && npm start`) runs end-to-end with the same lifecycle
- [ ] `recommendation` field is always a valid connector name (enforced by `json_schema` enum)
- [ ] No regex used anywhere for winner extraction