### PR TITLE
Add citation faithfulness check notebook (RAG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Disclaimer: Examples contributed by the community and partners do not represent 
 | [image_description_extraction_pixtral.ipynb](mistral/image_understanding/image_description_extraction_pixtral.ipynb) | image processing, prompting  | Extract structured image descriptions using Mistral's Pixtral model and JSON response formatting |
 | [multimodality meets function calling.ipynb](mistral/image_understanding/multimodality_meets_function_calling.ipynb) | image processing, function calling  | Extract table from image using Mistral's Pixtral model and use for function calling |
 | [mistral-reference-rag.ipynb](mistral/rag/mistral-reference-rag.ipynb) | RAG, function calling, references | Reference RAG with Mistral API |
+| [citation_faithfulness_check.ipynb](mistral/rag/citation_faithfulness_check.ipynb) | RAG, references, structured outputs, evaluation | Deterministically verify RAG citations are faithful to their sources (zero-token gate + optional judge) |
 | [moderation-explored.ipynb](mistral/moderation/moderation-explored.ipynb) | moderation | Quick exploration on safeguarding and Mistral's moderation API |
 | [system-level-guardrails.ipynb](mistral/moderation/system-level-guardrails.ipynb) | moderation | How to implement System Level Guardrails with Mistral API |
 | [document_understanding.ipynb](mistral/ocr/document_understanding.ipynb) | OCR, function calling | Document Understanding and Tool Usage with OCR |

--- a/mistral/rag/citation_faithfulness_check.ipynb
+++ b/mistral/rag/citation_faithfulness_check.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b038cf02",
+   "metadata": {},
+   "source": [
+    "# Check Citation Faithfulness in Mistral RAG\n",
+    "\n",
+    "Mistral RAG can cite its sources — with the References API (`ReferenceChunk`) or,\n",
+    "as here, by asking the model for **structured citations** via structured outputs.\n",
+    "Either way you get, for each claim, a source id and a quoted span. This notebook\n",
+    "adds the missing half: a deterministic check that each quoted span is actually\n",
+    "**faithful** to the source it is attributed to, before the answer reaches a user.\n",
+    "\n",
+    "The failure modes worth catching are the ones that read as authoritative and slip\n",
+    "past an LLM judge:\n",
+    "\n",
+    "- **fabricated** — a quoted span that appears in no source document;\n",
+    "- **frankenquote** — every word is real, but the exact span was never written\n",
+    "  contiguously;\n",
+    "- **misattributed** — a real span, but attributed to the wrong document.\n",
+    "\n",
+    "The pattern is *cheap deterministic detector → expensive judge*:\n",
+    "\n",
+    "1. A **0-token verbatim gate** (no model, no API key) checks each quote appears\n",
+    "   verbatim in the cited document. This alone rejects the three failure modes above\n",
+    "   and runs in CI.\n",
+    "2. An **optional Mistral judge** (LLM-as-a-judge, the same technique as\n",
+    "   `mistral/evaluation/RAG_evaluation.ipynb`) decides whether a *verbatim,\n",
+    "   correctly-attributed* quote actually **supports** the claim — a right quote can\n",
+    "   still be the wrong evidence. The burden of proof is on the citation: it defaults\n",
+    "   to unsupported and fails closed.\n",
+    "\n",
+    "The gate is inlined below; its standalone, framework-agnostic version lives at\n",
+    "[`verbatim-citation-gate`](https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "080fd3a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "\n",
+    "def normalize(text: str) -> str:\n",
+    "    \"\"\"Case/typography/whitespace-insensitive form for verbatim matching.\"\"\"\n",
+    "    text = text.lower()\n",
+    "    text = re.sub(r\"[‘’]\", \"'\", text)\n",
+    "    text = re.sub(r\"[“”]\", '\"', text)\n",
+    "    text = re.sub(r\"[–—]\", \"-\", text)\n",
+    "    text = re.sub(r\"[^a-z0-9%.]+\", \" \", text)\n",
+    "    return \" \".join(text.split())\n",
+    "\n",
+    "\n",
+    "def gate(quote: str, cited_doc_id: str, docs: dict) -> str:\n",
+    "    \"\"\"Return 'found' | 'misattributed' | 'not_found'. Fails closed on empty quotes.\"\"\"\n",
+    "    q = normalize(quote)\n",
+    "    if not q:\n",
+    "        return \"not_found\"\n",
+    "    cited = docs.get(cited_doc_id)\n",
+    "    if cited is not None and q in normalize(cited):\n",
+    "        return \"found\"\n",
+    "    if any(q in normalize(t) for d, t in docs.items() if d != cited_doc_id):\n",
+    "        return \"misattributed\"\n",
+    "    return \"not_found\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22ffba7c",
+   "metadata": {},
+   "source": [
+    "## 1. Run it offline on structured citations\n",
+    "\n",
+    "So the notebook runs in CI with no API key, here is a small document library and a\n",
+    "set of `(claim, document_id, quote)` citations in the shape you would get back from\n",
+    "Mistral structured outputs. One is faithful; the others are the three planted\n",
+    "failure modes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97fe66c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# document_id -> text (your RAG library / the docs you passed to Mistral)\n",
+    "DOCS = {\n",
+    "    \"doc_0\": \"Mistral Large 2 has a 128k token context window.\",\n",
+    "    \"doc_1\": \"Codestral is optimized for code generation across 80+ programming languages.\",\n",
+    "}\n",
+    "\n",
+    "# What Mistral structured outputs would return: a quote plus the source it cites.\n",
+    "CITATIONS = [\n",
+    "    {\"claim\": \"Mistral Large 2 supports a 128k context.\", \"document_id\": \"doc_0\",\n",
+    "     \"quote\": \"128k token context window\"},                                    # faithful\n",
+    "    {\"claim\": \"Codestral covers 80+ languages.\", \"document_id\": \"doc_0\",\n",
+    "     \"quote\": \"optimized for code generation across 80+ programming languages\"},  # wrong doc\n",
+    "    {\"claim\": \"Codestral has a 128k context for code.\", \"document_id\": \"doc_1\",\n",
+    "     \"quote\": \"128k token context window for code\"},                            # frankenquote\n",
+    "    {\"claim\": \"Mistral Large 2 runs fully offline.\", \"document_id\": \"doc_0\",\n",
+    "     \"quote\": \"runs entirely on-device with no network\"},                       # fabricated\n",
+    "]\n",
+    "\n",
+    "for c in CITATIONS:\n",
+    "    status = gate(c[\"quote\"], c[\"document_id\"], DOCS)\n",
+    "    flag = \"OK  \" if status == \"found\" else \"FLAG\"\n",
+    "    print(f\"{flag} [{status:>13}]  {c['claim']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "901e5bfe",
+   "metadata": {},
+   "source": [
+    "`found` citations are safe to surface; `misattributed` and `not_found` (fabricated\n",
+    "or frankenquote) should be flagged or dropped — decided deterministically, for zero\n",
+    "tokens."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b6b4a67",
+   "metadata": {},
+   "source": [
+    "## 2. Generate structured citations with Mistral\n",
+    "\n",
+    "With an API key, ask Mistral to answer **and** return structured citations, then run\n",
+    "the gate over them. This uses `response_format` for structured outputs and needs\n",
+    "`MISTRAL_API_KEY` (not run in CI)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9eda11a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pip install mistralai pydantic\n",
+    "import json\n",
+    "import os\n",
+    "\n",
+    "if not os.getenv(\"MISTRAL_API_KEY\"):\n",
+    "    print(\"Set MISTRAL_API_KEY to run the live example.\")\n",
+    "else:\n",
+    "    from mistralai import Mistral\n",
+    "    from pydantic import BaseModel\n",
+    "\n",
+    "    class Citation(BaseModel):\n",
+    "        claim: str\n",
+    "        document_id: str\n",
+    "        quote: str\n",
+    "\n",
+    "    class CitedAnswer(BaseModel):\n",
+    "        answer: str\n",
+    "        citations: list[Citation]\n",
+    "\n",
+    "    client = Mistral(api_key=os.environ[\"MISTRAL_API_KEY\"])\n",
+    "    library = \"\\n\".join(f\"[{doc_id}] {text}\" for doc_id, text in DOCS.items())\n",
+    "    resp = client.chat.parse(\n",
+    "        model=\"mistral-large-latest\",\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": \"Answer using only the library. For each claim, cite the document_id \"\n",
+    "             \"and a short quote copied verbatim from that document.\"},\n",
+    "            {\"role\": \"user\", \"content\": f\"Library:\\n{library}\\n\\nQuestion: What context window does Mistral Large 2 \"\n",
+    "             \"have, and how many languages does Codestral cover?\"},\n",
+    "        ],\n",
+    "        response_format=CitedAnswer,\n",
+    "    )\n",
+    "    cited = resp.choices[0].message.parsed\n",
+    "    print(cited.answer, \"\\n\")\n",
+    "    for c in cited.citations:\n",
+    "        status = gate(c.quote, c.document_id, DOCS)\n",
+    "        flag = \"OK  \" if status == \"found\" else \"FLAG\"\n",
+    "        print(f\"{flag} [{status:>13}]  {c.quote!r} -> {c.document_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "100f701e",
+   "metadata": {},
+   "source": [
+    "## 3. Optional: an LLM-as-a-judge for the ambiguous case\n",
+    "\n",
+    "The gate settles whether a quote *exists*. Whether a real, correctly-attributed\n",
+    "quote actually **supports** its claim is a judgment call — the same LLM-as-a-judge\n",
+    "pattern as `mistral/evaluation/RAG_evaluation.ipynb`, but with the burden of proof on\n",
+    "the citation (default to unsupported, fail closed). Only quotes that pass the gate\n",
+    "(`found`) need reach the judge, so fabrications cost zero judge calls.\n",
+    "\n",
+    "For a ready-made burden-of-proof judge (model-agnostic — plug in\n",
+    "`client.chat.complete`), see\n",
+    "[`verbatim-citation-gate`](https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Mistral RAG can cite its sources (the References API, or structured outputs that emit `(claim, document_id, quote)`). This notebook adds the missing half: a deterministic check that each quoted span is actually **faithful** to the source it is attributed to, before the answer reaches a user.

It catches the three failure modes that read as authoritative and slip past an LLM judge:

- **fabricated** — a quoted span in no source document;
- **frankenquote** — every word real, but the exact span was never written contiguously;
- **misattributed** — a real span attributed to the wrong document.

Pattern: *cheap deterministic detector → expensive judge*, the same shape as `mistral/evaluation/RAG_evaluation.ipynb`:

1. A **0-token verbatim gate** (no model, no key) — runs in CI.
2. An **optional Mistral LLM-as-a-judge** for the ambiguous "does this real quote actually *support* the claim?" case, with the burden of proof on the citation (fail closed).
3. A live section that generates structured citations via `response_format` (gated behind `MISTRAL_API_KEY`).

The offline section executes end-to-end (verified with `nbclient`):
```
OK   [        found]  Mistral Large 2 supports a 128k context.
FLAG [misattributed]  Codestral covers 80+ languages.
FLAG [    not_found]  Codestral has a 128k context for code.
FLAG [    not_found]  Mistral Large 2 runs fully offline.
```

Added to the RAG section of the README. The gate is inlined so the notebook has no extra dependency; its standalone, framework-agnostic version (gate + burden-of-proof judge) lives at https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate .