### PR TITLE
Restructure MCP server cookbook and fix AI move validation

### DIFF
--- a/mistral/lechat_custom_mcp_server/custom-mcp-server.md
+++ b/mistral/lechat_custom_mcp_server/custom-mcp-server.md
@@ -1,4 +1,4 @@
-# Build a custom MCP server for Vibe
+# Build a custom MCP server tic-tac-toe game for Vibe
 
 Build a tic-tac-toe MCP server powered by Mistral, deploy it to Hugging Face Spaces, and connect it to [Vibe](https://chat.mistral.ai) to play directly from the chat interface.
 
@@ -349,20 +349,22 @@ def get_ai_move_for_room(room):
         if i < 6:
             board_string += "---------\n"
 
+    empty_positions = [i for i in range(9) if room.board[i] == '']
+
     messages = [
         {
             "role": "system",
-            "content": """You are a competitive Tic-Tac-Toe AI with personality. You play as 'O' and the human plays as 'X'.
+            "content": f"""You are a competitive Tic-Tac-Toe AI with personality. You play as 'O' and the human plays as 'X'.
 
 Rules:
-1. Analyze the board and choose your best move (0-8, left to right, top to bottom)
+1. You MUST choose from these available positions ONLY: {empty_positions}
 2. Add a short, witty comment about your move or the game state
 3. Be competitive but fun - trash talk, celebrate good moves, react to the situation
 4. Keep messages under 50 words
 5. Use emojis occasionally
 
 ALWAYS respond with valid JSON in this exact format:
-{"move": [0-8], "message": "your witty comment"}
+{{"move": <one of {empty_positions}>, "message": "your witty comment"}}
 
 Board positions:
 0 | 1 | 2
@@ -373,7 +375,7 @@ Board positions:
         },
         {
             "role": "user",
-            "content": f"Current board:\n{board_string}\n\nBoard array: {room.board}"
+            "content": f"Current board:\n{board_string}\n\nAvailable positions: {empty_positions}\n\nBoard array: {room.board}"
         }
     ]
 
@@ -424,7 +426,7 @@ if __name__ == '__main__':
 
 The `Room` class tracks board state, move history, and chat messages. Each room gets a short UUID and supports the full game lifecycle: creating, making moves, checking winners, and chatting with the AI opponent.
 
-The two AI helper functions use `mistral-medium-latest` with different system prompts. `get_ai_move_for_room` uses JSON mode to get a structured move and trash-talk message. `get_ai_chat_for_room` handles freeform conversation during the game.
+The two AI helper functions use `mistral-medium-latest` with different system prompts. `get_ai_move_for_room` uses JSON mode to get a structured move and trash-talk message — the prompt explicitly lists which board positions are still empty so the model doesn't pick an occupied square. `get_ai_chat_for_room` handles freeform conversation during the game.
 
 The four Flask endpoints expose this logic as a REST API:
 
@@ -623,6 +625,14 @@ async def make_move(position: int, room_id: str = None) -> dict:
                     room.make_move(ai_move, 'O')
                     if 'message' in ai_response:
                         room.add_chat_message(ai_response['message'], 'ai')
+                else:
+                    # Fallback to first available position
+                    empty_positions = [i for i in range(9) if room.board[i] == '']
+                    if empty_positions:
+                        ai_move = empty_positions[0]
+                        ai_response['move'] = ai_move
+                        room.make_move(ai_move, 'O')
+                        room.add_chat_message("Oops, had a brain freeze! But I'm still playing!", 'ai')
 
                 result_message += f"🤖 Mistral AI played O at position {ai_response['move']}\n"
                 if 'message' in ai_response:

--- a/mistral/lechat_custom_mcp_server/tic-tac-toe/app.py
+++ b/mistral/lechat_custom_mcp_server/tic-tac-toe/app.py
@@ -257,20 +257,22 @@ def get_ai_move_for_room(room):
         if i < 6:
             board_string += "---------\n"
 
+    empty_positions = [i for i in range(9) if room.board[i] == '']
+
     messages = [
         {
             "role": "system",
-            "content": """You are a competitive Tic-Tac-Toe AI with personality. You play as 'O' and the human plays as 'X'.
+            "content": f"""You are a competitive Tic-Tac-Toe AI with personality. You play as 'O' and the human plays as 'X'.
 
 Rules:
-1. Analyze the board and choose your best move (0-8, left to right, top to bottom)
+1. You MUST choose from these available positions ONLY: {empty_positions}
 2. Add a short, witty comment about your move or the game state
 3. Be competitive but fun - trash talk, celebrate good moves, react to the situation
 4. Keep messages under 50 words
 5. Use emojis occasionally
 
 ALWAYS respond with valid JSON in this exact format:
-{"move": [0-8], "message": "your witty comment"}
+{{"move": <one of {empty_positions}>, "message": "your witty comment"}}
 
 Board positions:
 0 | 1 | 2
@@ -281,7 +283,7 @@ Board positions:
         },
         {
             "role": "user",
-            "content": f"Current board:\n{board_string}\n\nBoard array: {room.board}"
+            "content": f"Current board:\n{board_string}\n\nAvailable positions: {empty_positions}\n\nBoard array: {room.board}"
         }
     ]
 

--- a/mistral/lechat_custom_mcp_server/tic-tac-toe/mcp_server.py
+++ b/mistral/lechat_custom_mcp_server/tic-tac-toe/mcp_server.py
@@ -181,7 +181,15 @@ async def make_move(position: int, room_id: str = None) -> dict:
                     room.make_move(ai_move, 'O')
                     if 'message' in ai_response:
                         room.add_chat_message(ai_response['message'], 'ai')
-                
+                else:
+                    # Fallback to first available position
+                    empty_positions = [i for i in range(9) if room.board[i] == '']
+                    if empty_positions:
+                        ai_move = empty_positions[0]
+                        ai_response['move'] = ai_move
+                        room.make_move(ai_move, 'O')
+                        room.add_chat_message("Oops, had a brain freeze! But I'm still playing!", 'ai')
+
                 result_message += f"🤖 Mistral AI played O at position {ai_response['move']}\n"
                 if 'message' in ai_response:
                     result_message += f"💬 Mistral says: \"{ai_response['message']}\"\n\n"


### PR DESCRIPTION
## Summary
- Split the tic-tac-toe MCP server tutorial out of the project README into a standalone cookbook (`custom-mcp-server.md`) with environment setup, deploy flow, and cleanup steps
- Fix AI move validation: pass available board positions directly in the prompt so the model cannot pick an occupied square, and add a fallback in the MCP server's `make_move` tool when the AI returns an invalid move
- Clean up the project README to a minimal quickstart

## Test plan
- [ ] Verify `custom-mcp-server.md` renders correctly and code blocks match the source files
- [ ] Deploy the updated MCP server to a Hugging Face Space and confirm the AI no longer picks occupied squares
- [ ] Confirm the fallback logic activates when the AI returns an invalid position